### PR TITLE
fix: incorrect path when resolving `.`

### DIFF
--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -64,8 +64,11 @@ export function resolvePath(path: string, from: string, aliases: MaybeAliases) {
   if (matchedEntry)
     return path.replace(matchedEntry.find, matchedEntry.replacement)
 
-  // External package
-  const resolved_path = resolveModule(path)
+  /**
+   * External package
+   * If the path is just a single dot, append '/index' to prevent incorrect results
+   */
+  const resolved_path = resolveModule(path === '.' ? `${path}/index` : path)
 
   // Not a package. e.g. '../types'
   if (!resolved_path)

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -68,7 +68,7 @@ export function resolvePath(path: string, from: string, aliases: MaybeAliases) {
    * External package
    * If the path is just a single dot, append '/index' to prevent incorrect results
    */
-  const resolved_path = resolveModule(path === '.' ? `${path}/index` : path)
+  const resolved_path = resolveModule(path === '.' ? './index' : path)
 
   // Not a package. e.g. '../types'
   if (!resolved_path)


### PR DESCRIPTION
We will get wrong path if we don't append `/index` to the path

![image](https://user-images.githubusercontent.com/35414841/184535654-f87ee959-0b89-4b17-8e9c-14cc47c07758.png)
