### PR TITLE
feat: support more import/export syntaxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ import VueTypeImports from 'vite-plugin-vue-type-imports'
 export default defineConfig({
   plugins: [
     Vue(), 
-    VueTypeImports({/* options */}),
+    VueTypeImports(),
   ],
 })
 ```
@@ -64,37 +64,18 @@ defineProps<User>()
 <template>...</template>
 ```
 
-## Options
-```typescript
-VueTypeImports({
-  // Non-practical function
-  // Just for those who want to get a nice output
-  clean: {
-    // Clean redundant newlines ("\n")
-    newline: false,
-    // Clean isolated interfaces which are replaced by a new interface created by the plugin
-    interface: false,
-  }
-})
-```
-
 ## Known limitations
 - The following syntaxes are not supported currently:
-  - `import default`
-  - `import { a as b }`
-  - `export default`
-  - `export * from`
+  - `import * as Foo from 'foo'`
+  - `export * from 'foo'`
 - nested type parameters (e.g. `defineProps<Props<T>>()`) are not supported.
-- ~~At this stage, the plugin only scans the imported interfaces and does not process the interfaces defined in the SFC~~ Supported in the next release.
-- ~~HMR is not fully supported right now.~~ Fixed in the next release.
 - Interface which extends Literal Type or Intersection Type is not supported.
 - Types imported from external packages are not fully supported right now.
-- When interfaces implicitly rely on interfaces with the same name but different structures, the results may be different from what is expected.
 - The plugin currently only scans the content of `<script setup>`. Types defined in `<script>` will be ignored.
 
 ## Notes
 - `Enum` types will be converted to Union Types (e.g. `type [name] = number | string`) , since Vue can't handle them right now.
-- The plugin may be slow because it needs to traverse the AST (using @babel/parser).
+- The plugin may be slow because it needs to read files and traverse the AST (using @babel/parser).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -68,14 +68,33 @@ defineProps<User>()
 - The following syntaxes are not supported currently:
   - `import * as Foo from 'foo'`
   - `export * from 'foo'`
-- nested type parameters (e.g. `defineProps<Props<T>>()`) are not supported.
-- Interface which extends Literal Type or Intersection Type is not supported.
+- [These types](https://www.typescriptlang.org/docs/handbook/2/types-from-types.html) are not supported.
 - Types imported from external packages are not fully supported right now.
 - The plugin currently only scans the content of `<script setup>`. Types defined in `<script>` will be ignored.
 
 ## Notes
 - `Enum` types will be converted to Union Types (e.g. `type [name] = number | string`) , since Vue can't handle them right now.
 - The plugin may be slow because it needs to read files and traverse the AST (using @babel/parser).
+
+## Caveats
+It is not recommended to write **duplicate** imports/exports. It may affect the result of the plugin's transformation. You will get warnings if the plugin detects this kind of code.
+
+Examples:
+
+```javascript
+// These kinds of code will trigger warnings from the plugin
+import { Foo, Foo as Bar } from 'foo'
+
+import { Foo as Bar, Foo as Baz } from 'foo'
+
+export { Foo, Foo as Bar }
+
+export { Foo as Bar, Foo as Baz }
+
+export { Foo, Foo as Bar } from 'foo'
+
+export { Foo as Bar, Foo as Baz } from 'foo'
+```
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -38,30 +38,33 @@
   },
   "keywords": [],
   "devDependencies": {
-    "@antfu/eslint-config": "^0.25.2",
+    "@antfu/eslint-config": "^0.26.2",
     "@antfu/ni": "^0.17.2",
-    "@types/node": "^18.6.3",
-    "@vitest/ui": "^0.20.3",
-    "@vue/compiler-sfc": "^3.2.37",
+    "@types/debug": "^4.1.7",
+    "@types/node": "^18.7.14",
+    "@vitest/coverage-c8": "^0.22.1",
+    "@vitest/ui": "^0.22.1",
+    "@vue/compiler-sfc": "^3.2.38",
     "bumpp": "^8.2.1",
-    "c8": "^7.12.0",
     "cross-env": "^7.0.3",
-    "eslint": "^8.21.0",
+    "eslint": "^8.23.0",
     "esno": "^0.16.3",
     "git-ensure": "^0.1.0",
-    "tsup": "6.2.1",
-    "typescript": "^4.7.4",
-    "vite": "^3.0.4",
-    "vitest": "^0.20.3",
-    "vue": "^3.2.37"
+    "tsup": "6.2.3",
+    "typescript": "^4.8.2",
+    "vite": "^3.0.9",
+    "vitest": "^0.22.1",
+    "vue": "^3.2.38"
   },
   "peerDependencies": {
     "@vue/compiler-sfc": "^3.2.24",
     "vue": "^3.2.24"
   },
   "dependencies": {
-    "@babel/types": "^7.18.10",
+    "@babel/types": "^7.18.13",
+    "debug": "^4.3.4",
     "fast-glob": "^3.2.11",
-    "local-pkg": "^0.4.2"
+    "local-pkg": "^0.4.2",
+    "picocolors": "^1.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,49 +1,55 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 importers:
 
   .:
     specifiers:
-      '@antfu/eslint-config': ^0.25.2
+      '@antfu/eslint-config': ^0.26.2
       '@antfu/ni': ^0.17.2
-      '@babel/types': ^7.18.10
-      '@types/node': ^18.6.3
-      '@vitest/ui': ^0.20.3
-      '@vue/compiler-sfc': ^3.2.37
+      '@babel/types': ^7.18.13
+      '@types/debug': ^4.1.7
+      '@types/node': ^18.7.14
+      '@vitest/coverage-c8': ^0.22.1
+      '@vitest/ui': ^0.22.1
+      '@vue/compiler-sfc': ^3.2.38
       bumpp: ^8.2.1
-      c8: ^7.12.0
       cross-env: ^7.0.3
-      eslint: ^8.21.0
+      debug: ^4.3.4
+      eslint: ^8.23.0
       esno: ^0.16.3
       fast-glob: ^3.2.11
       git-ensure: ^0.1.0
       local-pkg: ^0.4.2
-      tsup: 6.2.1
-      typescript: ^4.7.4
-      vite: ^3.0.4
-      vitest: ^0.20.3
-      vue: ^3.2.37
+      picocolors: ^1.0.0
+      tsup: 6.2.3
+      typescript: ^4.8.2
+      vite: ^3.0.9
+      vitest: ^0.22.1
+      vue: ^3.2.38
     dependencies:
-      '@babel/types': 7.18.10
+      '@babel/types': 7.18.13
+      debug: 4.3.4
       fast-glob: 3.2.11
       local-pkg: 0.4.2
+      picocolors: 1.0.0
     devDependencies:
-      '@antfu/eslint-config': 0.25.2_eslint@8.21.0+typescript@4.7.4
+      '@antfu/eslint-config': 0.26.2_yqf6kl63nyoq5megxukfnom5rm
       '@antfu/ni': 0.17.2
-      '@types/node': 18.6.3
-      '@vitest/ui': 0.20.3
-      '@vue/compiler-sfc': 3.2.37
+      '@types/debug': 4.1.7
+      '@types/node': 18.7.14
+      '@vitest/coverage-c8': 0.22.1_@vitest+ui@0.22.1
+      '@vitest/ui': 0.22.1
+      '@vue/compiler-sfc': 3.2.38
       bumpp: 8.2.1
-      c8: 7.12.0
       cross-env: 7.0.3
-      eslint: 8.21.0
+      eslint: 8.23.0
       esno: 0.16.3
       git-ensure: 0.1.0
-      tsup: 6.2.1_typescript@4.7.4
-      typescript: 4.7.4
-      vite: 3.0.4
-      vitest: 0.20.3_@vitest+ui@0.20.3+c8@7.12.0
-      vue: 3.2.37
+      tsup: 6.2.3_typescript@4.8.2
+      typescript: 4.8.2
+      vite: 3.0.9
+      vitest: 0.22.1_@vitest+ui@0.22.1
+      vue: 3.2.38
 
   playground:
     specifiers:
@@ -86,92 +92,103 @@ packages:
       '@jridgewell/trace-mapping': 0.3.14
     dev: true
 
-  /@antfu/eslint-config-basic/0.25.2_eslint@8.21.0+typescript@4.7.4:
-    resolution: {integrity: sha512-D81jE90B7cujMmU2mKEaUcRsKRAfVX4PniEoaD0c3HiqprqghfBjuv3B6p1+tG9uJQAgLBVsK+G92Y+AAgFaOA==}
+  /@antfu/eslint-config-basic/0.26.2_3g5q5capxpyhialyvs33l4nssm:
+    resolution: {integrity: sha512-wPaKvRhymhaWhaJq4b/CiYnsZ/jONr7wVHy801p6kwUzUvekyY8ZAhU60YoDpb2J8Mh06268b0nHUlULgvMJAw==}
     peerDependencies:
       eslint: '>=7.4.0'
     dependencies:
-      eslint: 8.21.0
-      eslint-plugin-antfu: 0.25.2_eslint@8.21.0+typescript@4.7.4
-      eslint-plugin-eslint-comments: 3.2.0_eslint@8.21.0
-      eslint-plugin-html: 6.2.0
-      eslint-plugin-import: 2.26.0_eslint@8.21.0
-      eslint-plugin-jsonc: 2.3.1_eslint@8.21.0
-      eslint-plugin-markdown: 2.2.1_eslint@8.21.0
-      eslint-plugin-n: 15.2.4_eslint@8.21.0
-      eslint-plugin-promise: 6.0.0_eslint@8.21.0
-      eslint-plugin-unicorn: 42.0.0_eslint@8.21.0
-      eslint-plugin-yml: 1.1.0_eslint@8.21.0
+      eslint: 8.23.0
+      eslint-plugin-antfu: 0.26.2_yqf6kl63nyoq5megxukfnom5rm
+      eslint-plugin-eslint-comments: 3.2.0_eslint@8.23.0
+      eslint-plugin-html: 7.1.0
+      eslint-plugin-import: 2.26.0_en2wbs6aggmxy4drejzsyh4gce
+      eslint-plugin-jsonc: 2.4.0_eslint@8.23.0
+      eslint-plugin-markdown: 3.0.0_eslint@8.23.0
+      eslint-plugin-n: 15.2.5_eslint@8.23.0
+      eslint-plugin-promise: 6.0.1_eslint@8.23.0
+      eslint-plugin-unicorn: 43.0.2_eslint@8.23.0
+      eslint-plugin-yml: 1.1.0_eslint@8.23.0
       jsonc-eslint-parser: 2.1.0
       yaml-eslint-parser: 1.1.0
     transitivePeerDependencies:
+      - '@typescript-eslint/parser'
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
       - supports-color
       - typescript
     dev: true
 
-  /@antfu/eslint-config-react/0.25.2_eslint@8.21.0+typescript@4.7.4:
-    resolution: {integrity: sha512-jGol7/UTUa9z55p4Oy/K5yGgY179fj1kl0kdo3bRnFjzUZQuDGuxw5HiZdYx333pjBdizkPl6cMJ8M6sc3PzFg==}
+  /@antfu/eslint-config-react/0.26.2_yqf6kl63nyoq5megxukfnom5rm:
+    resolution: {integrity: sha512-/IxXC9mqtcT1MmXpmGLFH24eWSfuhFAezBvWfyDbbFzFFimzb6ud8n9/kidG9A3bTbc/aBfTKd/840aBL9kMhQ==}
     peerDependencies:
       eslint: '>=7.4.0'
     dependencies:
-      '@antfu/eslint-config-ts': 0.25.2_eslint@8.21.0+typescript@4.7.4
-      eslint: 8.21.0
-      eslint-plugin-react: 7.30.1_eslint@8.21.0
+      '@antfu/eslint-config-ts': 0.26.2_yqf6kl63nyoq5megxukfnom5rm
+      eslint: 8.23.0
+      eslint-plugin-react: 7.31.1_eslint@8.23.0
     transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
       - supports-color
       - typescript
     dev: true
 
-  /@antfu/eslint-config-ts/0.25.2_eslint@8.21.0+typescript@4.7.4:
-    resolution: {integrity: sha512-Dpp4r3CaDZVh73lMxhW0sVGsPwUf1YTpYV5JefmBtgEZKOAc+QqYbLjFZ6QGRUpdPLldRvD+xTFpax6t8NKgyA==}
+  /@antfu/eslint-config-ts/0.26.2_yqf6kl63nyoq5megxukfnom5rm:
+    resolution: {integrity: sha512-larpzAjXo565HGxUL8jg3ZDUwQ7kWnt5rdottCuW3grnkVL5PAE3wVvBktnYaPYyLxW/GdrTS6yGSrocCan7Iw==}
     peerDependencies:
       eslint: '>=7.4.0'
       typescript: '>=3.9'
     dependencies:
-      '@antfu/eslint-config-basic': 0.25.2_eslint@8.21.0+typescript@4.7.4
-      '@typescript-eslint/eslint-plugin': 5.32.0_43a51d9e2446a740dea4259743d3ab3e
-      '@typescript-eslint/parser': 5.32.0_eslint@8.21.0+typescript@4.7.4
-      eslint: 8.21.0
-      typescript: 4.7.4
+      '@antfu/eslint-config-basic': 0.26.2_3g5q5capxpyhialyvs33l4nssm
+      '@typescript-eslint/eslint-plugin': 5.36.1_3g5q5capxpyhialyvs33l4nssm
+      '@typescript-eslint/parser': 5.36.0_yqf6kl63nyoq5megxukfnom5rm
+      eslint: 8.23.0
+      typescript: 4.8.2
     transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
       - supports-color
     dev: true
 
-  /@antfu/eslint-config-vue/0.25.2_eslint@8.21.0+typescript@4.7.4:
-    resolution: {integrity: sha512-ObZOzvQvLe/qETq5miVmFWRgjNwWAE/P1I2YhKyDFK7KHquM7bKysfnmkoPpm2HkOpseMILoc+5UKo/w3L7GHg==}
+  /@antfu/eslint-config-vue/0.26.2_yqf6kl63nyoq5megxukfnom5rm:
+    resolution: {integrity: sha512-LcSo+V86f+BSc9eB4YNeAvw3GPQjcWE3wrK6VaOmKSlt4tOewj2usJa5jfhHpSsmdrBOw2ORMKd4+3iyx7bMtQ==}
     peerDependencies:
       eslint: '>=7.4.0'
     dependencies:
-      '@antfu/eslint-config-ts': 0.25.2_eslint@8.21.0+typescript@4.7.4
-      eslint: 8.21.0
-      eslint-plugin-vue: 9.3.0_eslint@8.21.0
+      '@antfu/eslint-config-ts': 0.26.2_yqf6kl63nyoq5megxukfnom5rm
+      eslint: 8.23.0
+      eslint-plugin-vue: 9.4.0_eslint@8.23.0
     transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
       - supports-color
       - typescript
     dev: true
 
-  /@antfu/eslint-config/0.25.2_eslint@8.21.0+typescript@4.7.4:
-    resolution: {integrity: sha512-dIqxqBa6ALqaBQyErMnYLpyn4xpwp1YefbYxDMgNFM8MzY/ShJgaBWAGlywFeDwyAR44jaaVY8wRwDxODF8bPg==}
+  /@antfu/eslint-config/0.26.2_yqf6kl63nyoq5megxukfnom5rm:
+    resolution: {integrity: sha512-IKnvTP7KJ+nYloYb8qzH1YGr5qvJqGGGq3q443t0TPn+93W0b+mU0T+wOWXimOlYimSes8Chi8/e4DZk7ZQRgg==}
     peerDependencies:
       eslint: '>=7.4.0'
     dependencies:
-      '@antfu/eslint-config-react': 0.25.2_eslint@8.21.0+typescript@4.7.4
-      '@antfu/eslint-config-vue': 0.25.2_eslint@8.21.0+typescript@4.7.4
-      '@typescript-eslint/eslint-plugin': 5.32.0_43a51d9e2446a740dea4259743d3ab3e
-      '@typescript-eslint/parser': 5.32.0_eslint@8.21.0+typescript@4.7.4
-      eslint: 8.21.0
-      eslint-plugin-eslint-comments: 3.2.0_eslint@8.21.0
-      eslint-plugin-html: 6.2.0
-      eslint-plugin-import: 2.26.0_eslint@8.21.0
-      eslint-plugin-jsonc: 2.3.1_eslint@8.21.0
-      eslint-plugin-n: 15.2.4_eslint@8.21.0
-      eslint-plugin-promise: 6.0.0_eslint@8.21.0
-      eslint-plugin-unicorn: 42.0.0_eslint@8.21.0
-      eslint-plugin-vue: 9.3.0_eslint@8.21.0
-      eslint-plugin-yml: 1.1.0_eslint@8.21.0
+      '@antfu/eslint-config-react': 0.26.2_yqf6kl63nyoq5megxukfnom5rm
+      '@antfu/eslint-config-vue': 0.26.2_yqf6kl63nyoq5megxukfnom5rm
+      '@typescript-eslint/eslint-plugin': 5.36.1_3g5q5capxpyhialyvs33l4nssm
+      '@typescript-eslint/parser': 5.36.0_yqf6kl63nyoq5megxukfnom5rm
+      eslint: 8.23.0
+      eslint-plugin-eslint-comments: 3.2.0_eslint@8.23.0
+      eslint-plugin-html: 7.1.0
+      eslint-plugin-import: 2.26.0_en2wbs6aggmxy4drejzsyh4gce
+      eslint-plugin-jsonc: 2.4.0_eslint@8.23.0
+      eslint-plugin-n: 15.2.5_eslint@8.23.0
+      eslint-plugin-promise: 6.0.1_eslint@8.23.0
+      eslint-plugin-unicorn: 43.0.2_eslint@8.23.0
+      eslint-plugin-vue: 9.4.0_eslint@8.23.0
+      eslint-plugin-yml: 1.1.0_eslint@8.23.0
       jsonc-eslint-parser: 2.1.0
       yaml-eslint-parser: 1.1.0
     transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
       - supports-color
       - typescript
     dev: true
@@ -223,8 +240,24 @@ packages:
     dependencies:
       '@babel/types': 7.18.10
 
+  /@babel/parser/7.18.13:
+    resolution: {integrity: sha512-dgXcIfMuQ0kgzLB2b9tRZs7TTFFaGM2AbtA4fJgUUYukzGH4jwsS7hzQHEGs67jdehpm22vkgKwvbU+aEflgwg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+    dependencies:
+      '@babel/types': 7.18.13
+    dev: true
+
   /@babel/types/7.18.10:
     resolution: {integrity: sha512-MJvnbEiiNkpjo+LknnmRrqbY1GPUUggjv+wQVjetM/AONoupqRALB7I6jGqNUAZsKcRIEu2J6FRFvsczljjsaQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-string-parser': 7.18.10
+      '@babel/helper-validator-identifier': 7.18.6
+      to-fast-properties: 2.0.0
+
+  /@babel/types/7.18.13:
+    resolution: {integrity: sha512-ePqfTihzW0W6XAU+aMw2ykilisStJfDnsejDCXRchCcMJ4O0+8DhPXf2YUbZ6wjBlsEmZwLK/sPweWtu8hcJYQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-string-parser': 7.18.10
@@ -235,24 +268,24 @@ packages:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: true
 
-  /@esbuild-kit/cjs-loader/2.3.2:
-    resolution: {integrity: sha512-3UIFKrGfq2d2R2A/SpJaeHTP5z3nrOnVMxE+cNpOuuW+Lotm0Sfbc9lVHCjcxaxgcx0MKI7g2FvxvWlylzDRKg==}
+  /@esbuild-kit/cjs-loader/2.3.3:
+    resolution: {integrity: sha512-Rt4O1mXlPEDVxvjsHLgbtHVdUXYK9C1/6ThpQnt7FaXIjUOsI6qhHYMgALhNnlIMZffag44lXd6Dqgx3xALbpQ==}
     dependencies:
-      '@esbuild-kit/core-utils': 2.1.0
+      '@esbuild-kit/core-utils': 2.3.0
       get-tsconfig: 4.2.0
     dev: true
 
-  /@esbuild-kit/core-utils/2.1.0:
-    resolution: {integrity: sha512-fZirrc2KjeTumVjE4bpleWOk2gD83b7WuGeQqOceKFQL+heNKKkNB5G5pekOUTLzfSBc0hP7hCSBoD9TuR0hLw==}
+  /@esbuild-kit/core-utils/2.3.0:
+    resolution: {integrity: sha512-JL73zt/LN/qqziHuod4/bM2xBNNofDZu1cbwT6KIn6B11lA4cgDXkoSHOfNCbZMZOnh0Aqf0vW/gNQC+Z18hKQ==}
     dependencies:
-      esbuild: 0.14.53
+      esbuild: 0.15.6
       source-map-support: 0.5.21
     dev: true
 
   /@esbuild-kit/esm-loader/2.4.2:
     resolution: {integrity: sha512-N9dPKAj8WOx6djVnStgILWXip4fjDcBk9L7azO0/uQDpu8Ee0eaL78mkN4Acid9BzvNAKWwdYXFJZnsVahNEew==}
     dependencies:
-      '@esbuild-kit/core-utils': 2.1.0
+      '@esbuild-kit/core-utils': 2.3.0
       get-tsconfig: 4.2.0
     dev: true
 
@@ -265,13 +298,31 @@ packages:
     dev: true
     optional: true
 
-  /@eslint/eslintrc/1.3.0:
-    resolution: {integrity: sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==}
+  /@esbuild/linux-loong64/0.14.54:
+    resolution: {integrity: sha512-bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-loong64/0.15.6:
+    resolution: {integrity: sha512-hqmVU2mUjH6J2ZivHphJ/Pdse2ZD+uGCHK0uvsiLDk/JnSedEVj77CiVUnbMKuU4tih1TZZL8tG9DExQg/GZsw==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@eslint/eslintrc/1.3.1:
+    resolution: {integrity: sha512-OhSY22oQQdw3zgPOOwdoj01l/Dzl1Z+xyUP33tkSN+aqyEhymJCcPHyXt+ylW8FSe0TfRC2VG+ROQOapD0aZSQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
       debug: 4.3.4
-      espree: 9.3.3
+      espree: 9.4.0
       globals: 13.17.0
       ignore: 5.2.0
       import-fresh: 3.3.0
@@ -295,6 +346,11 @@ packages:
 
   /@humanwhocodes/gitignore-to-minimatch/1.0.2:
     resolution: {integrity: sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==}
+    dev: true
+
+  /@humanwhocodes/module-importer/1.0.1:
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
     dev: true
 
   /@humanwhocodes/object-schema/1.2.1:
@@ -359,6 +415,13 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.14
     dev: true
 
+  /@jridgewell/trace-mapping/0.3.15:
+    resolution: {integrity: sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==}
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.0
+      '@jridgewell/sourcemap-codec': 1.4.14
+    dev: true
+
   /@jsdevtools/ez-spawn/3.0.4:
     resolution: {integrity: sha512-f5DRIOZf7wxogefH03RjMPMdBF7ADTWUMoOs9kaJo06EfwF+aFhMZMDZxHg/Xe12hptN9xoZjGso2fdjapBRIA==}
     engines: {node: '>=10'}
@@ -414,11 +477,17 @@ packages:
   /@types/chai-subset/1.3.3:
     resolution: {integrity: sha512-frBecisrNGz+F4T6bcc+NLeolfiojh5FxW2klu669+8BARtyQv2C/GkNW6FUodVe4BroGMP/wER/YDGc7rEllw==}
     dependencies:
-      '@types/chai': 4.3.1
+      '@types/chai': 4.3.3
     dev: true
 
-  /@types/chai/4.3.1:
-    resolution: {integrity: sha512-/zPMqDkzSZ8t3VtxOa4KPq7uzzW978M9Tvh+j7GHKuo6k6GTLxPJ4J5gE5cjfJ26pnXst0N5Hax8Sr0T2Mi9zQ==}
+  /@types/chai/4.3.3:
+    resolution: {integrity: sha512-hC7OMnszpxhZPduX+m+nrx+uFoLkWOMiR4oa/AZF3MuSETYTZmFfJAHqZEM8MVlvfG7BEUcgvtwoCTxBp6hm3g==}
+    dev: true
+
+  /@types/debug/4.1.7:
+    resolution: {integrity: sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==}
+    dependencies:
+      '@types/ms': 0.7.31
     dev: true
 
   /@types/istanbul-lib-coverage/2.0.4:
@@ -439,8 +508,12 @@ packages:
       '@types/unist': 2.0.6
     dev: true
 
-  /@types/node/18.6.3:
-    resolution: {integrity: sha512-6qKpDtoaYLM+5+AFChLhHermMQxc3TOEFIDzrZLPRGHPrLEwqFkkT5Kx3ju05g6X7uDPazz3jHbKPX0KzCjntg==}
+  /@types/ms/0.7.31:
+    resolution: {integrity: sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==}
+    dev: true
+
+  /@types/node/18.7.14:
+    resolution: {integrity: sha512-6bbDaETVi8oyIARulOE9qF1/Qdi/23z6emrUh0fNJRUmjznqrixD4MpGDdgOFk5Xb0m2H6Xu42JGdvAxaJR/wA==}
     dev: true
 
   /@types/normalize-package-data/2.4.1:
@@ -453,10 +526,9 @@ packages:
 
   /@types/web-bluetooth/0.0.15:
     resolution: {integrity: sha512-w7hEHXnPMEZ+4nGKl/KDRVpxkwYxYExuHOYXyzIzCDzEZ9ZCGMAewulr9IqJu2LR4N37fcnb1XVeuZ09qgOxhA==}
-    dev: false
 
-  /@typescript-eslint/eslint-plugin/5.32.0_43a51d9e2446a740dea4259743d3ab3e:
-    resolution: {integrity: sha512-CHLuz5Uz7bHP2WgVlvoZGhf0BvFakBJKAD/43Ty0emn4wXWv5k01ND0C0fHcl/Im8Td2y/7h44E9pca9qAu2ew==}
+  /@typescript-eslint/eslint-plugin/5.36.1_3g5q5capxpyhialyvs33l4nssm:
+    resolution: {integrity: sha512-iC40UK8q1tMepSDwiLbTbMXKDxzNy+4TfPWgIL661Ym0sD42vRcQU93IsZIrmi+x292DBr60UI/gSwfdVYexCA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       '@typescript-eslint/parser': ^5.0.0
@@ -466,24 +538,24 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.32.0_eslint@8.21.0+typescript@4.7.4
-      '@typescript-eslint/scope-manager': 5.32.0
-      '@typescript-eslint/type-utils': 5.32.0_eslint@8.21.0+typescript@4.7.4
-      '@typescript-eslint/utils': 5.32.0_eslint@8.21.0+typescript@4.7.4
+      '@typescript-eslint/parser': 5.36.0_yqf6kl63nyoq5megxukfnom5rm
+      '@typescript-eslint/scope-manager': 5.36.1
+      '@typescript-eslint/type-utils': 5.36.1_yqf6kl63nyoq5megxukfnom5rm
+      '@typescript-eslint/utils': 5.36.1_yqf6kl63nyoq5megxukfnom5rm
       debug: 4.3.4
-      eslint: 8.21.0
+      eslint: 8.23.0
       functional-red-black-tree: 1.0.1
       ignore: 5.2.0
       regexpp: 3.2.0
       semver: 7.3.7
-      tsutils: 3.21.0_typescript@4.7.4
-      typescript: 4.7.4
+      tsutils: 3.21.0_typescript@4.8.2
+      typescript: 4.8.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/5.32.0_eslint@8.21.0+typescript@4.7.4:
-    resolution: {integrity: sha512-IxRtsehdGV9GFQ35IGm5oKKR2OGcazUoiNBxhRV160iF9FoyuXxjY+rIqs1gfnd+4eL98OjeGnMpE7RF/NBb3A==}
+  /@typescript-eslint/parser/5.36.0_yqf6kl63nyoq5megxukfnom5rm:
+    resolution: {integrity: sha512-dlBZj7EGB44XML8KTng4QM0tvjI8swDh8MdpE5NX5iHWgWEfIuqSfSE+GPeCrCdj7m4tQLuevytd57jNDXJ2ZA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -492,26 +564,34 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/scope-manager': 5.32.0
-      '@typescript-eslint/types': 5.32.0
-      '@typescript-eslint/typescript-estree': 5.32.0_typescript@4.7.4
+      '@typescript-eslint/scope-manager': 5.36.0
+      '@typescript-eslint/types': 5.36.0
+      '@typescript-eslint/typescript-estree': 5.36.0_typescript@4.8.2
       debug: 4.3.4
-      eslint: 8.21.0
-      typescript: 4.7.4
+      eslint: 8.23.0
+      typescript: 4.8.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/scope-manager/5.32.0:
-    resolution: {integrity: sha512-KyAE+tUON0D7tNz92p1uetRqVJiiAkeluvwvZOqBmW9z2XApmk5WSMV9FrzOroAcVxJZB3GfUwVKr98Dr/OjOg==}
+  /@typescript-eslint/scope-manager/5.36.0:
+    resolution: {integrity: sha512-PZUC9sz0uCzRiuzbkh6BTec7FqgwXW03isumFVkuPw/Ug/6nbAqPUZaRy4w99WCOUuJTjhn3tMjsM94NtEj64g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      '@typescript-eslint/types': 5.32.0
-      '@typescript-eslint/visitor-keys': 5.32.0
+      '@typescript-eslint/types': 5.36.0
+      '@typescript-eslint/visitor-keys': 5.36.0
     dev: true
 
-  /@typescript-eslint/type-utils/5.32.0_eslint@8.21.0+typescript@4.7.4:
-    resolution: {integrity: sha512-0gSsIhFDduBz3QcHJIp3qRCvVYbqzHg8D6bHFsDMrm0rURYDj+skBK2zmYebdCp+4nrd9VWd13egvhYFJj/wZg==}
+  /@typescript-eslint/scope-manager/5.36.1:
+    resolution: {integrity: sha512-pGC2SH3/tXdu9IH3ItoqciD3f3RRGCh7hb9zPdN2Drsr341zgd6VbhP5OHQO/reUqihNltfPpMpTNihFMarP2w==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.36.1
+      '@typescript-eslint/visitor-keys': 5.36.1
+    dev: true
+
+  /@typescript-eslint/type-utils/5.36.1_yqf6kl63nyoq5megxukfnom5rm:
+    resolution: {integrity: sha512-xfZhfmoQT6m3lmlqDvDzv9TiCYdw22cdj06xY0obSznBsT///GK5IEZQdGliXpAOaRL34o8phEvXzEo/VJx13Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: '*'
@@ -520,22 +600,28 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/utils': 5.32.0_eslint@8.21.0+typescript@4.7.4
+      '@typescript-eslint/typescript-estree': 5.36.1_typescript@4.8.2
+      '@typescript-eslint/utils': 5.36.1_yqf6kl63nyoq5megxukfnom5rm
       debug: 4.3.4
-      eslint: 8.21.0
-      tsutils: 3.21.0_typescript@4.7.4
-      typescript: 4.7.4
+      eslint: 8.23.0
+      tsutils: 3.21.0_typescript@4.8.2
+      typescript: 4.8.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/types/5.32.0:
-    resolution: {integrity: sha512-EBUKs68DOcT/EjGfzywp+f8wG9Zw6gj6BjWu7KV/IYllqKJFPlZlLSYw/PTvVyiRw50t6wVbgv4p9uE2h6sZrQ==}
+  /@typescript-eslint/types/5.36.0:
+    resolution: {integrity: sha512-3JJuLL1r3ljRpFdRPeOtgi14Vmpx+2JcR6gryeORmW3gPBY7R1jNYoq4yBN1L//ONZjMlbJ7SCIwugOStucYiQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree/5.32.0_typescript@4.7.4:
-    resolution: {integrity: sha512-ZVAUkvPk3ITGtCLU5J4atCw9RTxK+SRc6hXqLtllC2sGSeMFWN+YwbiJR9CFrSFJ3w4SJfcWtDwNb/DmUIHdhg==}
+  /@typescript-eslint/types/5.36.1:
+    resolution: {integrity: sha512-jd93ShpsIk1KgBTx9E+hCSEuLCUFwi9V/urhjOWnOaksGZFbTOxAT47OH2d4NLJnLhkVD+wDbB48BuaycZPLBg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
+
+  /@typescript-eslint/typescript-estree/5.36.0_typescript@4.8.2:
+    resolution: {integrity: sha512-EW9wxi76delg/FS9+WV+fkPdwygYzRrzEucdqFVWXMQWPOjFy39mmNNEmxuO2jZHXzSQTXzhxiU1oH60AbIw9A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       typescript: '*'
@@ -543,41 +629,70 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/types': 5.32.0
-      '@typescript-eslint/visitor-keys': 5.32.0
+      '@typescript-eslint/types': 5.36.0
+      '@typescript-eslint/visitor-keys': 5.36.0
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.7
-      tsutils: 3.21.0_typescript@4.7.4
-      typescript: 4.7.4
+      tsutils: 3.21.0_typescript@4.8.2
+      typescript: 4.8.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils/5.32.0_eslint@8.21.0+typescript@4.7.4:
-    resolution: {integrity: sha512-W7lYIAI5Zlc5K082dGR27Fczjb3Q57ECcXefKU/f0ajM5ToM0P+N9NmJWip8GmGu/g6QISNT+K6KYB+iSHjXCQ==}
+  /@typescript-eslint/typescript-estree/5.36.1_typescript@4.8.2:
+    resolution: {integrity: sha512-ih7V52zvHdiX6WcPjsOdmADhYMDN15SylWRZrT2OMy80wzKbc79n8wFW0xpWpU0x3VpBz/oDgTm2xwDAnFTl+g==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 5.36.1
+      '@typescript-eslint/visitor-keys': 5.36.1
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.3.7
+      tsutils: 3.21.0_typescript@4.8.2
+      typescript: 4.8.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/utils/5.36.1_yqf6kl63nyoq5megxukfnom5rm:
+    resolution: {integrity: sha512-lNj4FtTiXm5c+u0pUehozaUWhh7UYKnwryku0nxJlYUEWetyG92uw2pr+2Iy4M/u0ONMKzfrx7AsGBTCzORmIg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@types/json-schema': 7.0.11
-      '@typescript-eslint/scope-manager': 5.32.0
-      '@typescript-eslint/types': 5.32.0
-      '@typescript-eslint/typescript-estree': 5.32.0_typescript@4.7.4
-      eslint: 8.21.0
+      '@typescript-eslint/scope-manager': 5.36.1
+      '@typescript-eslint/types': 5.36.1
+      '@typescript-eslint/typescript-estree': 5.36.1_typescript@4.8.2
+      eslint: 8.23.0
       eslint-scope: 5.1.1
-      eslint-utils: 3.0.0_eslint@8.21.0
+      eslint-utils: 3.0.0_eslint@8.23.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@typescript-eslint/visitor-keys/5.32.0:
-    resolution: {integrity: sha512-S54xOHZgfThiZ38/ZGTgB2rqx51CMJ5MCfVT2IplK4Q7hgzGfe0nLzLCcenDnc/cSjP568hdeKfeDcBgqNHD/g==}
+  /@typescript-eslint/visitor-keys/5.36.0:
+    resolution: {integrity: sha512-pdqSJwGKueOrpjYIex0T39xarDt1dn4p7XJ+6FqBWugNQwXlNGC5h62qayAIYZ/RPPtD+ButDWmpXT1eGtiaYg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      '@typescript-eslint/types': 5.32.0
+      '@typescript-eslint/types': 5.36.0
+      eslint-visitor-keys: 3.3.0
+    dev: true
+
+  /@typescript-eslint/visitor-keys/5.36.1:
+    resolution: {integrity: sha512-ojB9aRyRFzVMN3b5joSYni6FAS10BBSCAfKJhjJAV08t/a95aM6tAhz+O1jF+EtgxktuSO3wJysp2R+Def/IWQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.36.1
       eslint-visitor-keys: 3.3.0
     dev: true
 
@@ -733,8 +848,26 @@ packages:
       vue: 3.2.37
     dev: true
 
-  /@vitest/ui/0.20.3:
-    resolution: {integrity: sha512-Rlg+y3PtE5IcGPVmViF/BXM7euY7LG0yjfIvXKlF0L3OnNSVS8+esgLlAhaYftSJXtcunqa/cYXiQ+qFVTaBGw==}
+  /@vitest/coverage-c8/0.22.1_@vitest+ui@0.22.1:
+    resolution: {integrity: sha512-KOOYpO7EGpaF+nD8GD+Y05D0JtZp12NUu6DdLXvBPqSOPo2HkZ7KNBtfR0rb6gOy3NLtGiWTYTzCwhajgb2HlA==}
+    dependencies:
+      c8: 7.12.0
+      vitest: 0.22.1_@vitest+ui@0.22.1
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@vitest/browser'
+      - '@vitest/ui'
+      - happy-dom
+      - jsdom
+      - less
+      - sass
+      - stylus
+      - supports-color
+      - terser
+    dev: true
+
+  /@vitest/ui/0.22.1:
+    resolution: {integrity: sha512-iiM2JN+vzY8pEejUbPPi0EgkEselI3RvrgMPNUOalxQRgtlNVGyMsM0Re99xQsrZ/eBkHgWrlW216gNDoeD5cA==}
     dependencies:
       sirv: 2.0.2
     dev: true
@@ -747,11 +880,27 @@ packages:
       estree-walker: 2.0.2
       source-map: 0.6.1
 
+  /@vue/compiler-core/3.2.38:
+    resolution: {integrity: sha512-/FsvnSu7Z+lkd/8KXMa4yYNUiqQrI22135gfsQYVGuh5tqEgOB0XqrUdb/KnCLa5+TmQLPwvyUnKMyCpu+SX3Q==}
+    dependencies:
+      '@babel/parser': 7.18.13
+      '@vue/shared': 3.2.38
+      estree-walker: 2.0.2
+      source-map: 0.6.1
+    dev: true
+
   /@vue/compiler-dom/3.2.37:
     resolution: {integrity: sha512-yxJLH167fucHKxaqXpYk7x8z7mMEnXOw3G2q62FTkmsvNxu4FQSu5+3UMb+L7fjKa26DEzhrmCxAgFLLIzVfqQ==}
     dependencies:
       '@vue/compiler-core': 3.2.37
       '@vue/shared': 3.2.37
+
+  /@vue/compiler-dom/3.2.38:
+    resolution: {integrity: sha512-zqX4FgUbw56kzHlgYuEEJR8mefFiiyR3u96498+zWPsLeh1WKvgIReoNE+U7gG8bCUdvsrJ0JRmev0Ky6n2O0g==}
+    dependencies:
+      '@vue/compiler-core': 3.2.38
+      '@vue/shared': 3.2.38
+    dev: true
 
   /@vue/compiler-sfc/3.2.37:
     resolution: {integrity: sha512-+7i/2+9LYlpqDv+KTtWhOZH+pa8/HnX/905MdVmAcI/mPQOBwkHHIzrsEsucyOIZQYMkXUiTkmZq5am/NyXKkg==}
@@ -767,11 +916,33 @@ packages:
       postcss: 8.4.14
       source-map: 0.6.1
 
+  /@vue/compiler-sfc/3.2.38:
+    resolution: {integrity: sha512-KZjrW32KloMYtTcHAFuw3CqsyWc5X6seb8KbkANSWt3Cz9p2qA8c1GJpSkksFP9ABb6an0FLCFl46ZFXx3kKpg==}
+    dependencies:
+      '@babel/parser': 7.18.13
+      '@vue/compiler-core': 3.2.38
+      '@vue/compiler-dom': 3.2.38
+      '@vue/compiler-ssr': 3.2.38
+      '@vue/reactivity-transform': 3.2.38
+      '@vue/shared': 3.2.38
+      estree-walker: 2.0.2
+      magic-string: 0.25.9
+      postcss: 8.4.16
+      source-map: 0.6.1
+    dev: true
+
   /@vue/compiler-ssr/3.2.37:
     resolution: {integrity: sha512-7mQJD7HdXxQjktmsWp/J67lThEIcxLemz1Vb5I6rYJHR5vI+lON3nPGOH3ubmbvYGt8xEUaAr1j7/tIFWiEOqw==}
     dependencies:
       '@vue/compiler-dom': 3.2.37
       '@vue/shared': 3.2.37
+
+  /@vue/compiler-ssr/3.2.38:
+    resolution: {integrity: sha512-bm9jOeyv1H3UskNm4S6IfueKjUNFmi2kRweFIGnqaGkkRePjwEcfCVqyS3roe7HvF4ugsEkhf4+kIvDhip6XzQ==}
+    dependencies:
+      '@vue/compiler-dom': 3.2.38
+      '@vue/shared': 3.2.38
+    dev: true
 
   /@vue/reactivity-transform/3.2.37:
     resolution: {integrity: sha512-IWopkKEb+8qpu/1eMKVeXrK0NLw9HicGviJzhJDEyfxTR9e1WtpnnbYkJWurX6WwoFP0sz10xQg8yL8lgskAZg==}
@@ -782,10 +953,26 @@ packages:
       estree-walker: 2.0.2
       magic-string: 0.25.9
 
+  /@vue/reactivity-transform/3.2.38:
+    resolution: {integrity: sha512-3SD3Jmi1yXrDwiNJqQ6fs1x61WsDLqVk4NyKVz78mkaIRh6d3IqtRnptgRfXn+Fzf+m6B1KxBYWq1APj6h4qeA==}
+    dependencies:
+      '@babel/parser': 7.18.13
+      '@vue/compiler-core': 3.2.38
+      '@vue/shared': 3.2.38
+      estree-walker: 2.0.2
+      magic-string: 0.25.9
+    dev: true
+
   /@vue/reactivity/3.2.37:
     resolution: {integrity: sha512-/7WRafBOshOc6m3F7plwzPeCu/RCVv9uMpOwa/5PiY1Zz+WLVRWiy0MYKwmg19KBdGtFWsmZ4cD+LOdVPcs52A==}
     dependencies:
       '@vue/shared': 3.2.37
+
+  /@vue/reactivity/3.2.38:
+    resolution: {integrity: sha512-6L4myYcH9HG2M25co7/BSo0skKFHpAN8PhkNPM4xRVkyGl1K5M3Jx4rp5bsYhvYze2K4+l+pioN4e6ZwFLUVtw==}
+    dependencies:
+      '@vue/shared': 3.2.38
+    dev: true
 
   /@vue/runtime-core/3.2.37:
     resolution: {integrity: sha512-JPcd9kFyEdXLl/i0ClS7lwgcs0QpUAWj+SKX2ZC3ANKi1U4DOtiEr6cRqFXsPwY5u1L9fAjkinIdB8Rz3FoYNQ==}
@@ -793,12 +980,27 @@ packages:
       '@vue/reactivity': 3.2.37
       '@vue/shared': 3.2.37
 
+  /@vue/runtime-core/3.2.38:
+    resolution: {integrity: sha512-kk0qiSiXUU/IKxZw31824rxmFzrLr3TL6ZcbrxWTKivadoKupdlzbQM4SlGo4MU6Zzrqv4fzyUasTU1jDoEnzg==}
+    dependencies:
+      '@vue/reactivity': 3.2.38
+      '@vue/shared': 3.2.38
+    dev: true
+
   /@vue/runtime-dom/3.2.37:
     resolution: {integrity: sha512-HimKdh9BepShW6YozwRKAYjYQWg9mQn63RGEiSswMbW+ssIht1MILYlVGkAGGQbkhSh31PCdoUcfiu4apXJoPw==}
     dependencies:
       '@vue/runtime-core': 3.2.37
       '@vue/shared': 3.2.37
       csstype: 2.6.20
+
+  /@vue/runtime-dom/3.2.38:
+    resolution: {integrity: sha512-4PKAb/ck2TjxdMSzMsnHViOrrwpudk4/A56uZjhzvusoEU9xqa5dygksbzYepdZeB5NqtRw5fRhWIiQlRVK45A==}
+    dependencies:
+      '@vue/runtime-core': 3.2.38
+      '@vue/shared': 3.2.38
+      csstype: 2.6.20
+    dev: true
 
   /@vue/server-renderer/3.2.37_vue@3.2.37:
     resolution: {integrity: sha512-kLITEJvaYgZQ2h47hIzPh2K3jG8c1zCVbp/o/bzQOyvzaKiCquKS7AaioPI28GNxIsE/zSx+EwWYsNxDCX95MA==}
@@ -809,8 +1011,22 @@ packages:
       '@vue/shared': 3.2.37
       vue: 3.2.37
 
+  /@vue/server-renderer/3.2.38_vue@3.2.38:
+    resolution: {integrity: sha512-pg+JanpbOZ5kEfOZzO2bt02YHd+ELhYP8zPeLU1H0e7lg079NtuuSB8fjLdn58c4Ou8UQ6C1/P+528nXnLPAhA==}
+    peerDependencies:
+      vue: 3.2.38
+    dependencies:
+      '@vue/compiler-ssr': 3.2.38
+      '@vue/shared': 3.2.38
+      vue: 3.2.38
+    dev: true
+
   /@vue/shared/3.2.37:
     resolution: {integrity: sha512-4rSJemR2NQIo9Klm1vabqWjD8rs/ZaJSzMxkMNeJS6lHiUjjUeYFbooN19NgFjztubEKh3WlZUeOLVdbbUWHsw==}
+
+  /@vue/shared/3.2.38:
+    resolution: {integrity: sha512-dTyhTIRmGXBjxJE+skC8tTWCGLCVc4wQgRRLt8+O9p5ewBAjoBwtCAkLPrtToSr1xltoe3st21Pv953aOZ7alg==}
+    dev: true
 
   /@vueuse/core/9.1.0_vue@3.2.37:
     resolution: {integrity: sha512-BIroqvXEqt826aE9r3K5cox1zobuPuAzdYJ36kouC2TVhlXvFKIILgFVWrpp9HZPwB3aLzasmG3K87q7TSyXZg==}
@@ -822,11 +1038,9 @@ packages:
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
-    dev: false
 
   /@vueuse/metadata/9.1.0:
     resolution: {integrity: sha512-8OEhlog1iaAGTD3LICZ8oBGQdYeMwByvXetOtAOZCJOzyCRSwqwdggTsmVZZ1rkgYIEqgUBk942AsAPwM21s6A==}
-    dev: false
 
   /@vueuse/shared/9.1.0_vue@3.2.37:
     resolution: {integrity: sha512-pB/3njQu4tfJJ78ajELNda0yMG6lKfpToQW7Soe09CprF1k3QuyoNi1tBNvo75wBDJWD+LOnr+c4B5HZ39jY/Q==}
@@ -835,7 +1049,6 @@ packages:
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
-    dev: false
 
   /acorn-jsx/5.3.2_acorn@8.8.0:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -988,20 +1201,20 @@ packages:
     hasBin: true
     dependencies:
       '@jsdevtools/ez-spawn': 3.0.4
-      cac: 6.7.12
+      cac: 6.7.14
       fast-glob: 3.2.11
       kleur: 4.1.5
       prompts: 2.4.2
       semver: 7.3.7
     dev: true
 
-  /bundle-require/3.0.4_esbuild@0.14.53:
-    resolution: {integrity: sha512-VXG6epB1yrLAvWVQpl92qF347/UXmncQj7J3U8kZEbdVZ1ZkQyr4hYeL/9RvcE8vVVdp53dY78Fd/3pqfRqI1A==}
+  /bundle-require/3.1.0_esbuild@0.15.6:
+    resolution: {integrity: sha512-IIXtAO7fKcwPHNPt9kY/WNVJqy7NDy6YqJvv6ENH0TOZoJ+yjpEsn1w40WKZbR2ibfu5g1rfgJTvmFHpm5aOMA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     peerDependencies:
       esbuild: '>=0.13'
     dependencies:
-      esbuild: 0.14.53
+      esbuild: 0.15.6
       load-tsconfig: 0.2.3
     dev: true
 
@@ -1026,6 +1239,11 @@ packages:
 
   /cac/6.7.12:
     resolution: {integrity: sha512-rM7E2ygtMkJqD9c7WnFU6fruFcN3xe4FM5yUmgxhZzIKJk4uHl9U/fhwdajGFQbQuv43FAUo1Fe8gX/oIKDeSA==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /cac/6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
     dev: true
 
@@ -1156,7 +1374,7 @@ packages:
     dev: true
 
   /concat-map/0.0.1:
-    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
     dev: true
 
   /consola/2.15.3:
@@ -1205,12 +1423,22 @@ packages:
 
   /debug/2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.0.0
     dev: true
 
   /debug/3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.1.3
     dev: true
@@ -1225,7 +1453,6 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
-    dev: true
 
   /deep-eql/3.0.1:
     resolution: {integrity: sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==}
@@ -1275,31 +1502,31 @@ packages:
       esutils: 2.0.3
     dev: true
 
-  /dom-serializer/1.4.1:
-    resolution: {integrity: sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==}
+  /dom-serializer/2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
     dependencies:
       domelementtype: 2.3.0
-      domhandler: 4.3.1
-      entities: 2.2.0
+      domhandler: 5.0.3
+      entities: 4.3.1
     dev: true
 
   /domelementtype/2.3.0:
     resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
     dev: true
 
-  /domhandler/4.3.1:
-    resolution: {integrity: sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==}
+  /domhandler/5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
     dependencies:
       domelementtype: 2.3.0
     dev: true
 
-  /domutils/2.8.0:
-    resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
+  /domutils/3.0.1:
+    resolution: {integrity: sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==}
     dependencies:
-      dom-serializer: 1.4.1
+      dom-serializer: 2.0.0
       domelementtype: 2.3.0
-      domhandler: 4.3.1
+      domhandler: 5.0.3
     dev: true
 
   /duplexer/0.1.2:
@@ -1310,12 +1537,8 @@ packages:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
     dev: true
 
-  /entities/2.2.0:
-    resolution: {integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==}
-    dev: true
-
-  /entities/3.0.1:
-    resolution: {integrity: sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==}
+  /entities/4.3.1:
+    resolution: {integrity: sha512-o4q/dYJlmyjP2zfnaWDUC6A3BQFmVTX+tZPezK7k0GLSU9QYCauscf5Y+qcEPzKL+EixVouYDgLQK5H9GrLpkg==}
     engines: {node: '>=0.12'}
     dev: true
 
@@ -1347,7 +1570,7 @@ packages:
       is-weakref: 1.0.2
       object-inspect: 1.12.2
       object-keys: 1.1.1
-      object.assign: 4.1.2
+      object.assign: 4.1.4
       regexp.prototype.flags: 1.4.3
       string.prototype.trimend: 1.0.5
       string.prototype.trimstart: 1.0.5
@@ -1378,8 +1601,44 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-android-64/0.14.54:
+    resolution: {integrity: sha512-Tz2++Aqqz0rJ7kYBfz+iqyE3QMycD4vk7LBRyWaAVFgFtQ/O8EJOnVmTOiDWYZ/uYzB4kvP+bqejYdVKzE5lAQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-android-64/0.15.6:
+    resolution: {integrity: sha512-Z1CHSgB1crVQi2LKSBwSkpaGtaloVz0ZIYcRMsvHc3uSXcR/x5/bv9wcZspvH/25lIGTaViosciS/NS09ERmVA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-android-arm64/0.14.53:
     resolution: {integrity: sha512-PC7KaF1v0h/nWpvlU1UMN7dzB54cBH8qSsm7S9mkwFA1BXpaEOufCg8hdoEI1jep0KeO/rjZVWrsH8+q28T77A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-android-arm64/0.14.54:
+    resolution: {integrity: sha512-F9E+/QDi9sSkLaClO8SOV6etqPd+5DgJje1F9lOWoNncDdOBL2YF59IhsWATSt0TLZbYCf3pNlTHvVV5VfHdvg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-android-arm64/0.15.6:
+    resolution: {integrity: sha512-mvM+gqNxqKm2pCa3dnjdRzl7gIowuc4ga7P7c3yHzs58Im8v/Lfk1ixSgQ2USgIywT48QWaACRa3F4MG7djpSw==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -1396,8 +1655,44 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-darwin-64/0.14.54:
+    resolution: {integrity: sha512-jtdKWV3nBviOd5v4hOpkVmpxsBy90CGzebpbO9beiqUYVMBtSc0AL9zGftFuBon7PNDcdvNCEuQqw2x0wP9yug==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-darwin-64/0.15.6:
+    resolution: {integrity: sha512-BsfVt3usScAfGlXJiGtGamwVEOTM8AiYiw1zqDWhGv6BncLXCnTg1As+90mxWewdTZKq3iIy8s9g8CKkrrAXVw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-darwin-arm64/0.14.53:
     resolution: {integrity: sha512-otJwDU3hnI15Q98PX4MJbknSZ/WSR1I45il7gcxcECXzfN4Mrpft5hBDHXNRnCh+5858uPXBXA1Vaz2jVWLaIA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-darwin-arm64/0.14.54:
+    resolution: {integrity: sha512-OPafJHD2oUPyvJMrsCvDGkRrVCar5aVyHfWGQzY1dWnzErjrDuSETxwA2HSsyg2jORLY8yBfzc1MIpUkXlctmw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-darwin-arm64/0.15.6:
+    resolution: {integrity: sha512-CnrAeJaEpPakUobhqO4wVSA4Zm6TPaI5UY4EsI62j9mTrjIyQPXA1n4Ju6Iu5TVZRnEqV6q8blodgYJ6CJuwCA==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
@@ -1414,8 +1709,44 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-freebsd-64/0.14.54:
+    resolution: {integrity: sha512-OKwd4gmwHqOTp4mOGZKe/XUlbDJ4Q9TjX0hMPIDBUWWu/kwhBAudJdBoxnjNf9ocIB6GN6CPowYpR/hRCbSYAg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-freebsd-64/0.15.6:
+    resolution: {integrity: sha512-+qFdmqi+jkAsxsNJkaWVrnxEUUI50nu6c3MBVarv3RCDCbz7ZS1a4ZrdkwEYFnKcVWu6UUE0Kkb1SQ1yGEG6sg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-freebsd-arm64/0.14.53:
     resolution: {integrity: sha512-9T7WwCuV30NAx0SyQpw8edbKvbKELnnm1FHg7gbSYaatH+c8WJW10g/OdM7JYnv7qkimw2ZTtSA+NokOLd2ydQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-freebsd-arm64/0.14.54:
+    resolution: {integrity: sha512-sFwueGr7OvIFiQT6WeG0jRLjkjdqWWSrfbVwZp8iMP+8UHEHRBvlaxL6IuKNDwAozNUmbb8nIMXa7oAOARGs1Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-freebsd-arm64/0.15.6:
+    resolution: {integrity: sha512-KtQkQOhnNciXm2yrTYZMD3MOm2zBiiwFSU+dkwNbcfDumzzUprr1x70ClTdGuZwieBS1BM/k0KajRQX7r504Xw==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
@@ -1432,8 +1763,44 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-linux-32/0.14.54:
+    resolution: {integrity: sha512-1ZuY+JDI//WmklKlBgJnglpUL1owm2OX+8E1syCD6UAxcMM/XoWd76OHSjl/0MR0LisSAXDqgjT3uJqT67O3qw==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-32/0.15.6:
+    resolution: {integrity: sha512-IAkDNz3TpxwISTGVdQijwyHBZrbFgLlRi5YXcvaEHtgbmayLSDcJmH5nV1MFgo/x2QdKcHBkOYHdjhKxUAcPwg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-linux-64/0.14.53:
     resolution: {integrity: sha512-pP/FA55j/fzAV7N9DF31meAyjOH6Bjuo3aSKPh26+RW85ZEtbJv9nhoxmGTd9FOqjx59Tc1ZbrJabuiXlMwuZQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-64/0.14.54:
+    resolution: {integrity: sha512-EgjAgH5HwTbtNsTqQOXWApBaPVdDn7XcK+/PtJwZLT1UmpLoznPd8c5CxqsH2dQK3j05YsB3L17T8vE7cp4cCg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-64/0.15.6:
+    resolution: {integrity: sha512-gQPksyrEYfA4LJwyfTQWAZaVZCx4wpaLrSzo2+Xc9QLC+i/sMWmX31jBjrn4nLJCd79KvwCinto36QC7BEIU/A==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
@@ -1450,8 +1817,44 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-linux-arm/0.14.54:
+    resolution: {integrity: sha512-qqz/SjemQhVMTnvcLGoLOdFpCYbz4v4fUo+TfsWG+1aOu70/80RV6bgNpR2JCrppV2moUQkww+6bWxXRL9YMGw==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-arm/0.15.6:
+    resolution: {integrity: sha512-xZ0Bq2aivsthDjA/ytQZzxrxIZbG0ATJYMJxNeOIBc1zUjpbVpzBKgllOZMsTSXMHFHGrow6TnCcgwqY0+oEoQ==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-linux-arm64/0.14.53:
     resolution: {integrity: sha512-GDmWITT+PMsjCA6/lByYk7NyFssW4Q6in32iPkpjZ/ytSyH+xeEx8q7HG3AhWH6heemEYEWpTll/eui3jwlSnw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-arm64/0.14.54:
+    resolution: {integrity: sha512-WL71L+0Rwv+Gv/HTmxTEmpv0UgmxYa5ftZILVi2QmZBgX3q7+tDeOQNqGtdXSdsL8TQi1vIaVFHUPDe0O0kdig==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-arm64/0.15.6:
+    resolution: {integrity: sha512-aovDkclFa6C9EdZVBuOXxqZx83fuoq8097xZKhEPSygwuy4Lxs8J4anHG7kojAsR+31lfUuxzOo2tHxv7EiNHA==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
@@ -1468,8 +1871,44 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-linux-mips64le/0.14.54:
+    resolution: {integrity: sha512-qTHGQB8D1etd0u1+sB6p0ikLKRVuCWhYQhAHRPkO+OF3I/iSlTKNNS0Lh2Oc0g0UFGguaFZZiPJdJey3AGpAlw==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-mips64le/0.15.6:
+    resolution: {integrity: sha512-wVpW8wkWOGizsCqCwOR/G3SHwhaecpGy3fic9BF1r7vq4djLjUcA8KunDaBCjJ6TgLQFhJ98RjDuyEf8AGjAvw==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-linux-ppc64le/0.14.53:
     resolution: {integrity: sha512-ndnJmniKPCB52m+r6BtHHLAOXw+xBCWIxNnedbIpuREOcbSU/AlyM/2dA3BmUQhsHdb4w3amD5U2s91TJ3MzzA==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-ppc64le/0.14.54:
+    resolution: {integrity: sha512-j3OMlzHiqwZBDPRCDFKcx595XVfOfOnv68Ax3U4UKZ3MTYQB5Yz3X1mn5GnodEVYzhtZgxEBidLWeIs8FDSfrQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-ppc64le/0.15.6:
+    resolution: {integrity: sha512-z6w6gsPH/Y77uchocluDC8tkCg9rfkcPTePzZKNr879bF4tu7j9t255wuNOCE396IYEGxY7y8u2HJ9i7kjCLVw==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
@@ -1486,8 +1925,44 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-linux-riscv64/0.14.54:
+    resolution: {integrity: sha512-y7Vt7Wl9dkOGZjxQZnDAqqn+XOqFD7IMWiewY5SPlNlzMX39ocPQlOaoxvT4FllA5viyV26/QzHtvTjVNOxHZg==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-riscv64/0.15.6:
+    resolution: {integrity: sha512-pfK/3MJcmbfU399TnXW5RTPS1S+ID6ra+CVj9TFZ2s0q9Ja1F5A1VirUUvViPkjiw+Kq3zveyn6U09Wg1zJXrw==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-linux-s390x/0.14.53:
     resolution: {integrity: sha512-OCJlgdkB+XPYndHmw6uZT7jcYgzmx9K+28PVdOa/eLjdoYkeAFvH5hTwX4AXGLZLH09tpl4bVsEtvuyUldaNCg==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-s390x/0.14.54:
+    resolution: {integrity: sha512-zaHpW9dziAsi7lRcyV4r8dhfG1qBidQWUXweUjnw+lliChJqQr+6XD71K41oEIC3Mx1KStovEmlzm+MkGZHnHA==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-s390x/0.15.6:
+    resolution: {integrity: sha512-OZeeDu32liefcwAE63FhVqM4heWTC8E3MglOC7SK0KYocDdY/6jyApw0UDkDHlcEK9mW6alX/SH9r3PDjcCo/Q==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
@@ -1504,8 +1979,44 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-netbsd-64/0.14.54:
+    resolution: {integrity: sha512-PR01lmIMnfJTgeU9VJTDY9ZerDWVFIUzAtJuDHwwceppW7cQWjBBqP48NdeRtoP04/AtO9a7w3viI+PIDr6d+w==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-netbsd-64/0.15.6:
+    resolution: {integrity: sha512-kaxw61wcHMyiEsSsi5ut1YYs/hvTC2QkxJwyRvC2Cnsz3lfMLEu8zAjpBKWh9aU/N0O/gsRap4wTur5GRuSvBA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-openbsd-64/0.14.53:
     resolution: {integrity: sha512-eKQ30ZWe+WTZmteDYg8S+YjHV5s4iTxeSGhJKJajFfQx9TLZJvsJX0/paqwP51GicOUruFpSUAs2NCc0a4ivQQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-openbsd-64/0.14.54:
+    resolution: {integrity: sha512-Qyk7ikT2o7Wu76UsvvDS5q0amJvmRzDyVlL0qf5VLsLchjCa1+IAvd8kTBgUxD7VBUUVgItLkk609ZHUc1oCaw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-openbsd-64/0.15.6:
+    resolution: {integrity: sha512-CuoY60alzYfIZapUHqFXqXbj88bbRJu8Fp9okCSHRX2zWIcGz4BXAHXiG7dlCye5nFVrY72psesLuWdusyf2qw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
@@ -1522,8 +2033,44 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-sunos-64/0.14.54:
+    resolution: {integrity: sha512-28GZ24KmMSeKi5ueWzMcco6EBHStL3B6ubM7M51RmPwXQGLe0teBGJocmWhgwccA1GeFXqxzILIxXpHbl9Q/Kw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-sunos-64/0.15.6:
+    resolution: {integrity: sha512-1ceefLdPWcd1nW/ZLruPEYxeUEAVX0YHbG7w+BB4aYgfknaLGotI/ZvPWUZpzhC8l1EybrVlz++lm3E6ODIJOg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-windows-32/0.14.53:
     resolution: {integrity: sha512-m14XyWQP5rwGW0tbEfp95U6A0wY0DYPInWBB7D69FAXUpBpBObRoGTKRv36lf2RWOdE4YO3TNvj37zhXjVL5xg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-windows-32/0.14.54:
+    resolution: {integrity: sha512-T+rdZW19ql9MjS7pixmZYVObd9G7kcaZo+sETqNH4RCkuuYSuv9AGHUVnPoP9hhuE1WM1ZimHz1CIBHBboLU7w==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-windows-32/0.15.6:
+    resolution: {integrity: sha512-pBqdOsKqCD5LRYiwF29PJRDJZi7/Wgkz46u3d17MRFmrLFcAZDke3nbdDa1c8YgY78RiemudfCeAemN8EBlIpA==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
@@ -1540,8 +2087,44 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-windows-64/0.14.54:
+    resolution: {integrity: sha512-AoHTRBUuYwXtZhjXZbA1pGfTo8cJo3vZIcWGLiUcTNgHpJJMC1rVA44ZereBHMJtotyN71S8Qw0npiCIkW96cQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-windows-64/0.15.6:
+    resolution: {integrity: sha512-KpPOh4aTOo//g9Pk2oVAzXMpc9Sz9n5A9sZTmWqDSXCiiachfFhbuFlsKBGATYCVitXfmBIJ4nNYYWSOdz4hQg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-windows-arm64/0.14.53:
     resolution: {integrity: sha512-E+5Gvb+ZWts+00T9II6wp2L3KG2r3iGxByqd/a1RmLmYWVsSVUjkvIxZuJ3hYTIbhLkH5PRwpldGTKYqVz0nzQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-windows-arm64/0.14.54:
+    resolution: {integrity: sha512-M0kuUvXhot1zOISQGXwWn6YtS+Y/1RT9WrVIOywZnJHo3jCDyewAc79aKNQWFCQm+xNHVTq9h8dZKvygoXQQRg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-windows-arm64/0.15.6:
+    resolution: {integrity: sha512-DB3G2x9OvFEa00jV+OkDBYpufq5x/K7a6VW6E2iM896DG4ZnAvJKQksOsCPiM1DUaa+DrijXAQ/ZOcKAqf/3Hg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
@@ -1578,6 +2161,64 @@ packages:
       esbuild-windows-arm64: 0.14.53
     dev: true
 
+  /esbuild/0.14.54:
+    resolution: {integrity: sha512-Cy9llcy8DvET5uznocPyqL3BFRrFXSVqbgpMJ9Wz8oVjZlh/zUSNbPRbov0VX7VxN2JH1Oa0uNxZ7eLRb62pJA==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/linux-loong64': 0.14.54
+      esbuild-android-64: 0.14.54
+      esbuild-android-arm64: 0.14.54
+      esbuild-darwin-64: 0.14.54
+      esbuild-darwin-arm64: 0.14.54
+      esbuild-freebsd-64: 0.14.54
+      esbuild-freebsd-arm64: 0.14.54
+      esbuild-linux-32: 0.14.54
+      esbuild-linux-64: 0.14.54
+      esbuild-linux-arm: 0.14.54
+      esbuild-linux-arm64: 0.14.54
+      esbuild-linux-mips64le: 0.14.54
+      esbuild-linux-ppc64le: 0.14.54
+      esbuild-linux-riscv64: 0.14.54
+      esbuild-linux-s390x: 0.14.54
+      esbuild-netbsd-64: 0.14.54
+      esbuild-openbsd-64: 0.14.54
+      esbuild-sunos-64: 0.14.54
+      esbuild-windows-32: 0.14.54
+      esbuild-windows-64: 0.14.54
+      esbuild-windows-arm64: 0.14.54
+    dev: true
+
+  /esbuild/0.15.6:
+    resolution: {integrity: sha512-sgLOv3l4xklvXzzczhRwKRotyrfyZ2i1fCS6PTOLPd9wevDPArGU8HFtHrHCOcsMwTjLjzGm15gvC8uxVzQf+w==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/linux-loong64': 0.15.6
+      esbuild-android-64: 0.15.6
+      esbuild-android-arm64: 0.15.6
+      esbuild-darwin-64: 0.15.6
+      esbuild-darwin-arm64: 0.15.6
+      esbuild-freebsd-64: 0.15.6
+      esbuild-freebsd-arm64: 0.15.6
+      esbuild-linux-32: 0.15.6
+      esbuild-linux-64: 0.15.6
+      esbuild-linux-arm: 0.15.6
+      esbuild-linux-arm64: 0.15.6
+      esbuild-linux-mips64le: 0.15.6
+      esbuild-linux-ppc64le: 0.15.6
+      esbuild-linux-riscv64: 0.15.6
+      esbuild-linux-s390x: 0.15.6
+      esbuild-netbsd-64: 0.15.6
+      esbuild-openbsd-64: 0.15.6
+      esbuild-sunos-64: 0.15.6
+      esbuild-windows-32: 0.15.6
+      esbuild-windows-64: 0.15.6
+      esbuild-windows-arm64: 0.15.6
+    dev: true
+
   /escalade/3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
     engines: {node: '>=6'}
@@ -1603,67 +2244,95 @@ packages:
     dependencies:
       debug: 3.2.7
       resolve: 1.22.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /eslint-module-utils/2.7.3:
-    resolution: {integrity: sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==}
+  /eslint-module-utils/2.7.4_xkxb4lzhcyntw6mmn4s5kvlnz4:
+    resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
     engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint:
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
     dependencies:
+      '@typescript-eslint/parser': 5.36.0_yqf6kl63nyoq5megxukfnom5rm
       debug: 3.2.7
-      find-up: 2.1.0
+      eslint: 8.23.0
+      eslint-import-resolver-node: 0.3.6
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /eslint-plugin-antfu/0.25.2_eslint@8.21.0+typescript@4.7.4:
-    resolution: {integrity: sha512-yRhuFMwUKhSYm8BWTZsW4ymYnFPCJWZb2LzjG+mQb7JbKflk73JIFMCREPOaV4nWwc4YJEPhym75QsC7AFbqSw==}
+  /eslint-plugin-antfu/0.26.2_yqf6kl63nyoq5megxukfnom5rm:
+    resolution: {integrity: sha512-WlrMC8DVTehsb6ha3xnALLtWVVSJvIpzdAgS0ZEUS9wQzsU+VoR71aShzbUZPgSK3iiB+mP8aKHDtwcYnV6wsA==}
     dependencies:
-      '@typescript-eslint/utils': 5.32.0_eslint@8.21.0+typescript@4.7.4
+      '@typescript-eslint/utils': 5.36.1_yqf6kl63nyoq5megxukfnom5rm
     transitivePeerDependencies:
       - eslint
       - supports-color
       - typescript
     dev: true
 
-  /eslint-plugin-es/4.1.0_eslint@8.21.0:
+  /eslint-plugin-es/4.1.0_eslint@8.23.0:
     resolution: {integrity: sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==}
     engines: {node: '>=8.10.0'}
     peerDependencies:
       eslint: '>=4.19.1'
     dependencies:
-      eslint: 8.21.0
+      eslint: 8.23.0
       eslint-utils: 2.1.0
       regexpp: 3.2.0
     dev: true
 
-  /eslint-plugin-eslint-comments/3.2.0_eslint@8.21.0:
+  /eslint-plugin-eslint-comments/3.2.0_eslint@8.23.0:
     resolution: {integrity: sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==}
     engines: {node: '>=6.5.0'}
     peerDependencies:
       eslint: '>=4.19.1'
     dependencies:
       escape-string-regexp: 1.0.5
-      eslint: 8.21.0
+      eslint: 8.23.0
       ignore: 5.2.0
     dev: true
 
-  /eslint-plugin-html/6.2.0:
-    resolution: {integrity: sha512-vi3NW0E8AJombTvt8beMwkL1R/fdRWl4QSNRNMhVQKWm36/X0KF0unGNAY4mqUF06mnwVWZcIcerrCnfn9025g==}
+  /eslint-plugin-html/7.1.0:
+    resolution: {integrity: sha512-fNLRraV/e6j8e3XYOC9xgND4j+U7b1Rq+OygMlLcMg+wI/IpVbF+ubQa3R78EjKB9njT6TQOlcK5rFKBVVtdfg==}
     dependencies:
-      htmlparser2: 7.2.0
+      htmlparser2: 8.0.1
     dev: true
 
-  /eslint-plugin-import/2.26.0_eslint@8.21.0:
+  /eslint-plugin-import/2.26.0_en2wbs6aggmxy4drejzsyh4gce:
     resolution: {integrity: sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==}
     engines: {node: '>=4'}
     peerDependencies:
+      '@typescript-eslint/parser': '*'
       eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
     dependencies:
+      '@typescript-eslint/parser': 5.36.0_yqf6kl63nyoq5megxukfnom5rm
       array-includes: 3.1.5
       array.prototype.flat: 1.3.0
       debug: 2.6.9
       doctrine: 2.1.0
-      eslint: 8.21.0
+      eslint: 8.23.0
       eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.3
+      eslint-module-utils: 2.7.4_xkxb4lzhcyntw6mmn4s5kvlnz4
       has: 1.0.3
       is-core-module: 2.10.0
       is-glob: 4.0.3
@@ -1671,42 +2340,46 @@ packages:
       object.values: 1.1.5
       resolve: 1.22.1
       tsconfig-paths: 3.14.1
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
     dev: true
 
-  /eslint-plugin-jsonc/2.3.1_eslint@8.21.0:
-    resolution: {integrity: sha512-8sgWGWiVRMFL6xGawRymrE4RjZJgiU0rXYgFFb71wvdwuUkPgWSvfFtc8jfwcgjjqFjis8vzCUFsg7SciMEDWw==}
+  /eslint-plugin-jsonc/2.4.0_eslint@8.23.0:
+    resolution: {integrity: sha512-YXy5PjyUL9gFYal6pYijd8P6EmpeWskv7PVhB9Py/AwKPn+hwnQHcIzQILiLfxztfhtWiRIUSzoLe/JThZgSUw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: '>=6.0.0'
     dependencies:
-      eslint: 8.21.0
-      eslint-utils: 3.0.0_eslint@8.21.0
+      eslint: 8.23.0
+      eslint-utils: 3.0.0_eslint@8.23.0
       jsonc-eslint-parser: 2.1.0
       natural-compare: 1.4.0
     dev: true
 
-  /eslint-plugin-markdown/2.2.1_eslint@8.21.0:
-    resolution: {integrity: sha512-FgWp4iyYvTFxPwfbxofTvXxgzPsDuSKHQy2S+a8Ve6savbujey+lgrFFbXQA0HPygISpRYWYBjooPzhYSF81iA==}
-    engines: {node: ^8.10.0 || ^10.12.0 || >= 12.0.0}
+  /eslint-plugin-markdown/3.0.0_eslint@8.23.0:
+    resolution: {integrity: sha512-hRs5RUJGbeHDLfS7ELanT0e29Ocyssf/7kBM+p7KluY5AwngGkDf8Oyu4658/NZSGTTq05FZeWbkxXtbVyHPwg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
-      eslint: '>=6.0.0'
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      eslint: 8.21.0
+      eslint: 8.23.0
       mdast-util-from-markdown: 0.8.5
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /eslint-plugin-n/15.2.4_eslint@8.21.0:
-    resolution: {integrity: sha512-tjnVMv2fiXYMnuiIFI8QMtyUFI42SckEEWvi8h68SWGWshfqO6SSCASy24dGMGAiy7NUk6DZt90DM0iNUsmQ5w==}
+  /eslint-plugin-n/15.2.5_eslint@8.23.0:
+    resolution: {integrity: sha512-8+BYsqiyZfpu6NXmdLOXVUfk8IocpCjpd8nMRRH0A9ulrcemhb2VI9RSJMEy5udx++A/YcVPD11zT8hpFq368g==}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       eslint: '>=7.0.0'
     dependencies:
       builtins: 5.0.1
-      eslint: 8.21.0
-      eslint-plugin-es: 4.1.0_eslint@8.21.0
-      eslint-utils: 3.0.0_eslint@8.21.0
+      eslint: 8.23.0
+      eslint-plugin-es: 4.1.0_eslint@8.23.0
+      eslint-utils: 3.0.0_eslint@8.23.0
       ignore: 5.2.0
       is-core-module: 2.10.0
       minimatch: 3.1.2
@@ -1714,17 +2387,17 @@ packages:
       semver: 7.3.7
     dev: true
 
-  /eslint-plugin-promise/6.0.0_eslint@8.21.0:
-    resolution: {integrity: sha512-7GPezalm5Bfi/E22PnQxDWH2iW9GTvAlUNTztemeHb6c1BniSyoeTrM87JkC0wYdi6aQrZX9p2qEiAno8aTcbw==}
+  /eslint-plugin-promise/6.0.1_eslint@8.23.0:
+    resolution: {integrity: sha512-uM4Tgo5u3UWQiroOyDEsYcVMOo7re3zmno0IZmB5auxoaQNIceAbXEkSt8RNrKtaYehARHG06pYK6K1JhtP0Zw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
     dependencies:
-      eslint: 8.21.0
+      eslint: 8.23.0
     dev: true
 
-  /eslint-plugin-react/7.30.1_eslint@8.21.0:
-    resolution: {integrity: sha512-NbEvI9jtqO46yJA3wcRF9Mo0lF9T/jhdHqhCHXiXtD+Zcb98812wvokjWpU7Q4QH5edo6dmqrukxVvWWXHlsUg==}
+  /eslint-plugin-react/7.31.1_eslint@8.23.0:
+    resolution: {integrity: sha512-j4/2xWqt/R7AZzG8CakGHA6Xa/u7iR8Q3xCxY+AUghdT92bnIDOBEefV456OeH0QvBcroVc0eyvrrLSyQGYIfg==}
     engines: {node: '>=4'}
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
@@ -1732,9 +2405,9 @@ packages:
       array-includes: 3.1.5
       array.prototype.flatmap: 1.3.0
       doctrine: 2.1.0
-      eslint: 8.21.0
+      eslint: 8.23.0
       estraverse: 5.3.0
-      jsx-ast-utils: 3.3.2
+      jsx-ast-utils: 3.3.3
       minimatch: 3.1.2
       object.entries: 1.1.5
       object.fromentries: 2.0.5
@@ -1746,17 +2419,17 @@ packages:
       string.prototype.matchall: 4.0.7
     dev: true
 
-  /eslint-plugin-unicorn/42.0.0_eslint@8.21.0:
-    resolution: {integrity: sha512-ixBsbhgWuxVaNlPTT8AyfJMlhyC5flCJFjyK3oKE8TRrwBnaHvUbuIkCM1lqg8ryYrFStL/T557zfKzX4GKSlg==}
-    engines: {node: '>=12'}
+  /eslint-plugin-unicorn/43.0.2_eslint@8.23.0:
+    resolution: {integrity: sha512-DtqZ5mf/GMlfWoz1abIjq5jZfaFuHzGBZYIeuJfEoKKGWRHr2JiJR+ea+BF7Wx2N1PPRoT/2fwgiK1NnmNE3Hg==}
+    engines: {node: '>=14.18'}
     peerDependencies:
-      eslint: '>=8.8.0'
+      eslint: '>=8.18.0'
     dependencies:
       '@babel/helper-validator-identifier': 7.18.6
       ci-info: 3.3.2
       clean-regexp: 1.0.0
-      eslint: 8.21.0
-      eslint-utils: 3.0.0_eslint@8.21.0
+      eslint: 8.23.0
+      eslint-utils: 3.0.0_eslint@8.23.0
       esquery: 1.4.0
       indent-string: 4.0.0
       is-builtin-module: 3.2.0
@@ -1769,32 +2442,32 @@ packages:
       strip-indent: 3.0.0
     dev: true
 
-  /eslint-plugin-vue/9.3.0_eslint@8.21.0:
-    resolution: {integrity: sha512-iscKKkBZgm6fGZwFt6poRoWC0Wy2dQOlwUPW++CiPoQiw1enctV2Hj5DBzzjJZfyqs+FAXhgzL4q0Ww03AgSmQ==}
+  /eslint-plugin-vue/9.4.0_eslint@8.23.0:
+    resolution: {integrity: sha512-Nzz2QIJ8FG+rtJaqT/7/ru5ie2XgT9KCudkbN0y3uFYhQ41nuHEaboLAiqwMcK006hZPQv/rVMRhUIwEGhIvfQ==}
     engines: {node: ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.2.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      eslint: 8.21.0
-      eslint-utils: 3.0.0_eslint@8.21.0
+      eslint: 8.23.0
+      eslint-utils: 3.0.0_eslint@8.23.0
       natural-compare: 1.4.0
       nth-check: 2.1.1
       postcss-selector-parser: 6.0.10
       semver: 7.3.7
-      vue-eslint-parser: 9.0.3_eslint@8.21.0
+      vue-eslint-parser: 9.0.3_eslint@8.23.0
       xml-name-validator: 4.0.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /eslint-plugin-yml/1.1.0_eslint@8.21.0:
+  /eslint-plugin-yml/1.1.0_eslint@8.23.0:
     resolution: {integrity: sha512-64g3vWwolk9d+FykuqxXGLn3oGEK2ZecIAyfIEsyuSHBQkR8utp5h8e75R6tGph1IRggoGl27QQ2oi2M1IF1Vw==}
     engines: {node: ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: '>=6.0.0'
     dependencies:
       debug: 4.3.4
-      eslint: 8.21.0
+      eslint: 8.23.0
       lodash: 4.17.21
       natural-compare: 1.4.0
       yaml-eslint-parser: 1.1.0
@@ -1825,13 +2498,13 @@ packages:
       eslint-visitor-keys: 1.3.0
     dev: true
 
-  /eslint-utils/3.0.0_eslint@8.21.0:
+  /eslint-utils/3.0.0_eslint@8.23.0:
     resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
     engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
     peerDependencies:
       eslint: '>=5'
     dependencies:
-      eslint: 8.21.0
+      eslint: 8.23.0
       eslint-visitor-keys: 2.1.0
     dev: true
 
@@ -1850,14 +2523,15 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /eslint/8.21.0:
-    resolution: {integrity: sha512-/XJ1+Qurf1T9G2M5IHrsjp+xrGT73RZf23xA1z5wB1ZzzEAWSZKvRwhWxTFp1rvkvCfwcvAUNAP31bhKTTGfDA==}
+  /eslint/8.23.0:
+    resolution: {integrity: sha512-pBG/XOn0MsJcKcTRLr27S5HpzQo4kLr+HjLQIyK4EiCsijDl/TB+h5uEuJU6bQ8Edvwz1XWOjpaP2qgnXGpTcA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     hasBin: true
     dependencies:
-      '@eslint/eslintrc': 1.3.0
+      '@eslint/eslintrc': 1.3.1
       '@humanwhocodes/config-array': 0.10.4
       '@humanwhocodes/gitignore-to-minimatch': 1.0.2
+      '@humanwhocodes/module-importer': 1.0.1
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
@@ -1865,9 +2539,9 @@ packages:
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.1.1
-      eslint-utils: 3.0.0_eslint@8.21.0
+      eslint-utils: 3.0.0_eslint@8.23.0
       eslint-visitor-keys: 3.3.0
-      espree: 9.3.3
+      espree: 9.4.0
       esquery: 1.4.0
       esutils: 2.0.3
       fast-deep-equal: 3.1.3
@@ -1893,7 +2567,6 @@ packages:
       strip-ansi: 6.0.1
       strip-json-comments: 3.1.1
       text-table: 0.2.0
-      v8-compile-cache: 2.3.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1902,11 +2575,11 @@ packages:
     resolution: {integrity: sha512-6slSBEV1lMKcX13DBifvnDFpNno5WXhw4j/ff7RI0y51BZiDqEe5dNhhjhIQ3iCOQuzsm2MbVzmwqbN78BBhPg==}
     hasBin: true
     dependencies:
-      tsx: 3.8.0
+      tsx: 3.9.0
     dev: true
 
-  /espree/9.3.3:
-    resolution: {integrity: sha512-ORs1Rt/uQTqUKjDdGCyrtYxbazf5umATSf/K4qxjmZHORR6HJk+2s/2Pqe+Kk49HHINC/xNIrGfgh8sZcll0ng==}
+  /espree/9.4.0:
+    resolution: {integrity: sha512-DQmnRpLj7f6TgN/NYb0MTzJXL+vJF9h3pHy4JhCIs3zwcgez8xmGg3sXHcEO97BrmO2OSvCwMdfdlyl+E9KjOw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       acorn: 8.8.0
@@ -2001,13 +2674,6 @@ packages:
     dependencies:
       to-regex-range: 5.0.1
 
-  /find-up/2.1.0:
-    resolution: {integrity: sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==}
-    engines: {node: '>=4'}
-    dependencies:
-      locate-path: 2.0.0
-    dev: true
-
   /find-up/4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
@@ -2028,12 +2694,12 @@ packages:
     resolution: {integrity: sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==}
     engines: {node: ^10.12.0 || >=12.0.0}
     dependencies:
-      flatted: 3.2.6
+      flatted: 3.2.7
       rimraf: 3.0.2
     dev: true
 
-  /flatted/3.2.6:
-    resolution: {integrity: sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==}
+  /flatted/3.2.7:
+    resolution: {integrity: sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==}
     dev: true
 
   /foreground-child/2.0.0:
@@ -2116,7 +2782,7 @@ packages:
     resolution: {integrity: sha512-eSV3haXStF4co7OxAMWS1+5/7hkjUNEHcbszjRk/ZPcHoTq9tfDcxTFJNUpNRXGVct1Ke1INJHDq8Lcf2pxBYg==}
     hasBin: true
     dependencies:
-      cac: 6.7.12
+      cac: 6.7.14
       chalk: 4.1.2
       debug: 4.3.4
       simple-git: 2.48.0
@@ -2236,13 +2902,13 @@ packages:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
     dev: true
 
-  /htmlparser2/7.2.0:
-    resolution: {integrity: sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==}
+  /htmlparser2/8.0.1:
+    resolution: {integrity: sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==}
     dependencies:
       domelementtype: 2.3.0
-      domhandler: 4.3.1
-      domutils: 2.8.0
-      entities: 3.0.1
+      domhandler: 5.0.3
+      domutils: 3.0.1
+      entities: 4.3.1
     dev: true
 
   /human-signals/2.1.0:
@@ -2504,7 +3170,7 @@ packages:
     dependencies:
       acorn: 8.8.0
       eslint-visitor-keys: 3.3.0
-      espree: 9.3.3
+      espree: 9.4.0
       semver: 7.3.7
     dev: true
 
@@ -2512,12 +3178,12 @@ packages:
     resolution: {integrity: sha512-DRf0QjnNeCUds3xTjKlQQ3DpJD51GvDjJfnxUVWg6PZTo2otSm+slzNAxU/35hF8/oJIKoG9slq30JYOsF2azg==}
     dev: true
 
-  /jsx-ast-utils/3.3.2:
-    resolution: {integrity: sha512-4ZCADZHRkno244xlNnn4AOG6sRQ7iBZ5BbgZ4vW4y5IZw7cVUD1PPeblm1xx/nfmMxPdt/LHsXZW8z/j58+l9Q==}
+  /jsx-ast-utils/3.3.3:
+    resolution: {integrity: sha512-fYQHZTZ8jSfmWZ0iyzfwiU4WDX4HpHbMCZ3gPlWYiCl3BoeOTsqKBqnTVfH2rYT7eP5c3sVbeSPHnnJOaTrWiw==}
     engines: {node: '>=4.0'}
     dependencies:
       array-includes: 3.1.5
-      object.assign: 4.1.2
+      object.assign: 4.1.4
     dev: true
 
   /kleur/3.0.3:
@@ -2559,14 +3225,6 @@ packages:
   /local-pkg/0.4.2:
     resolution: {integrity: sha512-mlERgSPrbxU3BP4qBqAvvwlgW4MTg78iwJdGGnv7kibKjWcJksrG3t6LB5lXI93wXRDvG4NpUgJFmTG4T6rdrg==}
     engines: {node: '>=14'}
-
-  /locate-path/2.0.0:
-    resolution: {integrity: sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==}
-    engines: {node: '>=4'}
-    dependencies:
-      p-locate: 2.0.0
-      path-exists: 3.0.0
-    dev: true
 
   /locate-path/5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
@@ -2723,7 +3381,6 @@ packages:
 
   /ms/2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
-    dev: true
 
   /ms/2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -2791,8 +3448,8 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
-  /object.assign/4.1.2:
-    resolution: {integrity: sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==}
+  /object.assign/4.1.4:
+    resolution: {integrity: sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
@@ -2869,13 +3526,6 @@ packages:
       word-wrap: 1.2.3
     dev: true
 
-  /p-limit/1.3.0:
-    resolution: {integrity: sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==}
-    engines: {node: '>=4'}
-    dependencies:
-      p-try: 1.0.0
-    dev: true
-
   /p-limit/2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
@@ -2890,13 +3540,6 @@ packages:
       yocto-queue: 0.1.0
     dev: true
 
-  /p-locate/2.0.0:
-    resolution: {integrity: sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==}
-    engines: {node: '>=4'}
-    dependencies:
-      p-limit: 1.3.0
-    dev: true
-
   /p-locate/4.1.0:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
     engines: {node: '>=8'}
@@ -2909,11 +3552,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       p-limit: 3.1.0
-    dev: true
-
-  /p-try/1.0.0:
-    resolution: {integrity: sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==}
-    engines: {node: '>=4'}
     dev: true
 
   /p-try/2.2.0:
@@ -2947,11 +3585,6 @@ packages:
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
-    dev: true
-
-  /path-exists/3.0.0:
-    resolution: {integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==}
-    engines: {node: '>=4'}
     dev: true
 
   /path-exists/4.0.0:
@@ -3046,6 +3679,15 @@ packages:
       nanoid: 3.3.4
       picocolors: 1.0.0
       source-map-js: 1.0.2
+
+  /postcss/8.4.16:
+    resolution: {integrity: sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.4
+      picocolors: 1.0.0
+      source-map-js: 1.0.2
+    dev: true
 
   /prelude-ls/1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -3177,6 +3819,22 @@ packages:
       fsevents: 2.3.2
     dev: true
 
+  /rollup/2.77.3:
+    resolution: {integrity: sha512-/qxNTG7FbmefJWoeeYJFbHehJ2HNWnjkAFRKzWN/45eNBBF/r8lo992CwcJXEzyVxs5FmfId+vTSTQDb+bxA+g==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
+  /rollup/2.78.1:
+    resolution: {integrity: sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
   /run-parallel/1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
@@ -3295,7 +3953,7 @@ packages:
     resolution: {integrity: sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==}
     dependencies:
       spdx-expression-parse: 3.0.1
-      spdx-license-ids: 3.0.11
+      spdx-license-ids: 3.0.12
     dev: true
 
   /spdx-exceptions/2.3.0:
@@ -3306,11 +3964,11 @@ packages:
     resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
     dependencies:
       spdx-exceptions: 2.3.0
-      spdx-license-ids: 3.0.11
+      spdx-license-ids: 3.0.12
     dev: true
 
-  /spdx-license-ids/3.0.11:
-    resolution: {integrity: sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==}
+  /spdx-license-ids/3.0.12:
+    resolution: {integrity: sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==}
     dev: true
 
   /string-argv/0.3.1:
@@ -3454,8 +4112,8 @@ packages:
     engines: {node: '>=14.0.0'}
     dev: true
 
-  /tinyspy/1.0.0:
-    resolution: {integrity: sha512-FI5B2QdODQYDRjfuLF+OrJ8bjWRMCXokQPcwKm0W3IzcbUmBNv536cQc7eXGoAuXphZwgx1DFbqImwzz08Fnhw==}
+  /tinyspy/1.0.2:
+    resolution: {integrity: sha512-bSGlgwLBYf7PnUsQ6WOc6SJ3pGOcd+d8AA6EUnLDDM0kWEstC1JIlSZA3UNliDXhd9ABoS7hiRBDCu+XP/sf1Q==}
     engines: {node: '>=14.0.0'}
     dev: true
 
@@ -3502,8 +4160,8 @@ packages:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
     dev: true
 
-  /tsup/6.2.1_typescript@4.7.4:
-    resolution: {integrity: sha512-KhBhCqVA3bHrIWhkcqTUA7R69H05IcBlHEtCVLEu42XDGUzz+bDqCcfu5PwpkKJ8DqK5tpdgM/qmyk4DdUbkZw==}
+  /tsup/6.2.3_typescript@4.8.2:
+    resolution: {integrity: sha512-J5Pu2Dx0E1wlpIEsVFv9ryzP1pZ1OYsJ2cBHZ7GrKteytNdzaSz5hmLX7/nAxtypq+jVkVvA79d7S83ETgHQ5w==}
     engines: {node: '>=14'}
     hasBin: true
     peerDependencies:
@@ -3518,42 +4176,42 @@ packages:
       typescript:
         optional: true
     dependencies:
-      bundle-require: 3.0.4_esbuild@0.14.53
-      cac: 6.7.12
+      bundle-require: 3.1.0_esbuild@0.15.6
+      cac: 6.7.14
       chokidar: 3.5.3
       debug: 4.3.4
-      esbuild: 0.14.53
+      esbuild: 0.15.6
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
       postcss-load-config: 3.1.4
       resolve-from: 5.0.0
-      rollup: 2.77.2
+      rollup: 2.78.1
       source-map: 0.8.0-beta.0
       sucrase: 3.25.0
       tree-kill: 1.2.2
-      typescript: 4.7.4
+      typescript: 4.8.2
     transitivePeerDependencies:
       - supports-color
       - ts-node
     dev: true
 
-  /tsutils/3.21.0_typescript@4.7.4:
+  /tsutils/3.21.0_typescript@4.8.2:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 4.7.4
+      typescript: 4.8.2
     dev: true
 
-  /tsx/3.8.0:
-    resolution: {integrity: sha512-PcvTwRXTm6hDWfPihA4n5WW/9SmgFNxKaDKqvLLG+FKNEPA4crsipChzC7PVozPtdOaMfR5QctDlkC/hKoIsxw==}
+  /tsx/3.9.0:
+    resolution: {integrity: sha512-ofxsE+qjqCYYq4UBt5khglvb+ESgxef1YpuNcdQI92kvcAT2tZVrnSK3g4bRXTUhLmKHcC5q8vIZA47os/stng==}
     hasBin: true
     dependencies:
-      '@esbuild-kit/cjs-loader': 2.3.2
-      '@esbuild-kit/core-utils': 2.1.0
+      '@esbuild-kit/cjs-loader': 2.3.3
+      '@esbuild-kit/core-utils': 2.3.0
       '@esbuild-kit/esm-loader': 2.4.2
     optionalDependencies:
       fsevents: 2.3.2
@@ -3586,8 +4244,8 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /typescript/4.7.4:
-    resolution: {integrity: sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==}
+  /typescript/4.8.2:
+    resolution: {integrity: sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==}
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: true
@@ -3760,15 +4418,11 @@ packages:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
     dev: true
 
-  /v8-compile-cache/2.3.0:
-    resolution: {integrity: sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==}
-    dev: true
-
   /v8-to-istanbul/9.0.1:
     resolution: {integrity: sha512-74Y4LqY74kLE6IFyIjPtkSTWzUZmj8tdHT9Ii/26dvQ6K9Dl2NbEfj0XgU2sHCtKgt5VupqhlO/5aWuqS+IY1w==}
     engines: {node: '>=10.12.0'}
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.14
+      '@jridgewell/trace-mapping': 0.3.15
       '@types/istanbul-lib-coverage': 2.0.4
       convert-source-map: 1.8.0
     dev: true
@@ -3823,15 +4477,41 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /vitest/0.20.3_@vitest+ui@0.20.3+c8@7.12.0:
-    resolution: {integrity: sha512-cXMjTbZxBBUUuIF3PUzEGPLJWtIMeURBDXVxckSHpk7xss4JxkiiWh5cnIlfGyfJne2Ii3QpbiRuFL5dMJtljw==}
+  /vite/3.0.9:
+    resolution: {integrity: sha512-waYABTM+G6DBTCpYAxvevpG50UOlZuynR0ckTK5PawNVt7ebX6X7wNXHaGIO6wYYFXSM7/WcuFuO2QzhBB6aMw==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
+    peerDependencies:
+      less: '*'
+      sass: '*'
+      stylus: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      less:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      esbuild: 0.14.54
+      postcss: 8.4.16
+      resolve: 1.22.1
+      rollup: 2.77.3
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
+  /vitest/0.22.1_@vitest+ui@0.22.1:
+    resolution: {integrity: sha512-+x28YTnSLth4KbXg7MCzoDAzPJlJex7YgiZbUh6YLp0/4PqVZ7q7/zyfdL0OaPtKTpNiQFPpMC8Y2MSzk8F7dw==}
     engines: {node: '>=v14.16.0'}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@vitest/browser': '*'
       '@vitest/ui': '*'
-      c8: '*'
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -3841,24 +4521,21 @@ packages:
         optional: true
       '@vitest/ui':
         optional: true
-      c8:
-        optional: true
       happy-dom:
         optional: true
       jsdom:
         optional: true
     dependencies:
-      '@types/chai': 4.3.1
+      '@types/chai': 4.3.3
       '@types/chai-subset': 1.3.3
-      '@types/node': 18.6.3
-      '@vitest/ui': 0.20.3
-      c8: 7.12.0
+      '@types/node': 18.7.14
+      '@vitest/ui': 0.22.1
       chai: 4.3.6
       debug: 4.3.4
       local-pkg: 0.4.2
       tinypool: 0.2.4
-      tinyspy: 1.0.0
-      vite: 3.0.4
+      tinyspy: 1.0.2
+      vite: 3.0.9
     transitivePeerDependencies:
       - less
       - sass
@@ -3880,19 +4557,18 @@ packages:
         optional: true
     dependencies:
       vue: 3.2.37
-    dev: false
 
-  /vue-eslint-parser/9.0.3_eslint@8.21.0:
+  /vue-eslint-parser/9.0.3_eslint@8.23.0:
     resolution: {integrity: sha512-yL+ZDb+9T0ELG4VIFo/2anAOz8SvBdlqEnQnvJ3M7Scq56DvtjY0VY88bByRZB0D4J0u8olBcfrXTVONXsh4og==}
     engines: {node: ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: '>=6.0.0'
     dependencies:
       debug: 4.3.4
-      eslint: 8.21.0
+      eslint: 8.23.0
       eslint-scope: 7.1.1
       eslint-visitor-keys: 3.3.0
-      espree: 9.3.3
+      espree: 9.4.0
       esquery: 1.4.0
       lodash: 4.17.21
       semver: 7.3.7
@@ -3908,6 +4584,16 @@ packages:
       '@vue/runtime-dom': 3.2.37
       '@vue/server-renderer': 3.2.37_vue@3.2.37
       '@vue/shared': 3.2.37
+
+  /vue/3.2.38:
+    resolution: {integrity: sha512-hHrScEFSmDAWL0cwO4B6WO7D3sALZPbfuThDsGBebthrNlDxdJZpGR3WB87VbjpPh96mep1+KzukYEhpHDFa8Q==}
+    dependencies:
+      '@vue/compiler-dom': 3.2.38
+      '@vue/compiler-sfc': 3.2.38
+      '@vue/runtime-dom': 3.2.38
+      '@vue/server-renderer': 3.2.38_vue@3.2.38
+      '@vue/shared': 3.2.38
+    dev: true
 
   /webidl-conversions/4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -1,0 +1,15 @@
+// Vue macros
+export const DEFINE_PROPS = 'defineProps'
+export const DEFINE_EMITS = 'defineEmits'
+export const WITH_DEFAULTS = 'withDefaults'
+
+export const PLUGIN_NAME = 'vite-plugin-vue-type-imports'
+
+// Typescript types that the plugin allow to extract.
+export const TS_TYPES_KEYS = ['TSTypeAliasDeclaration', 'TSInterfaceDeclaration', 'TSEnumDeclaration']
+
+// Messages that can be reused for logger
+export enum LogMsg {
+  SUGGEST_TYPE_ALIAS = 'If you want to use types with the same definition but different names, use type alias instead!',
+  UNEXPECTED_RESULT = 'The results of the transformation will likely not meet your expectations.',
+}

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -49,8 +49,10 @@ export function debuggerFactory(namespace: string) {
      * NOTE(zorin): Use `console.log` instead when testing.
      * Because the output of the default logger is incomplete (i.e. it will lost some debug messages) when testing.
      */
-    if (import.meta.vitest)
+    if (import.meta.vitest) {
+      /* eslint-disable-next-line no-console */
       _debugger.log = console.log.bind(console)
+    }
 
     return _debugger
   }

--- a/src/nuxt.ts
+++ b/src/nuxt.ts
@@ -1,7 +1,7 @@
 import VueTypeImports from './vite'
 
-export default function (this: any) {
-  this.nuxt.hook('vite:extend', async (vite: any) => {
+export default function (_inlineOptions: any, nuxt: any) {
+  nuxt.hook('vite:extend', async (vite: any) => {
     vite.config.plugins = vite.config.plugins || []
     vite.config.plugins.unshift(VueTypeImports())
   })

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -1,17 +1,12 @@
 import type { Plugin, ResolvedConfig } from 'vite'
-import type { CleanOptions } from './core'
 import { transform } from './core'
+import { PLUGIN_NAME } from './core/constants'
 
-interface PluginOptions {
-  clean?: CleanOptions
-}
-
-export default function VitePluginVueTypeImports(options: PluginOptions = {}): Plugin {
-  const clean = options.clean ?? {}
+export default function VitePluginVueTypeImports(): Plugin {
   let resolvedConfig: ResolvedConfig | undefined
 
   return {
-    name: 'vite-plugin-vue-type-imports',
+    name: PLUGIN_NAME,
     enforce: 'pre',
     async configResolved(config) {
       resolvedConfig = config
@@ -25,7 +20,6 @@ export default function VitePluginVueTypeImports(options: PluginOptions = {}): P
       const transformedCode = await transform(code, {
         id,
         aliases,
-        clean,
       })
 
       return {

--- a/test/__snapshots__/common.test.ts.snap
+++ b/test/__snapshots__/common.test.ts.snap
@@ -1,42 +1,174 @@
 // Vitest Snapshot v1
 
-exports[`Common > Interface extends interface > No reference > index.ts (clean all) 1`] = `
+exports[`Common > Export aliases > Default > index.ts (default) 1`] = `
 "<script lang=\\"ts\\" setup>
+type _VTI_TYPE_Foo = string
 interface Props {
-  baz: boolean
-
-  foo: string
-  bar: number
+  foo: _VTI_TYPE_Foo
 }
 defineProps<Props>()
 </script>
 "
 `;
 
-exports[`Common > Interface extends interface > No reference > index.ts (clean interface) 1`] = `
+exports[`Common > Export aliases > Multi level > 1.ts (default) 1`] = `
 "<script lang=\\"ts\\" setup>
 interface Props {
-  baz: boolean
-
   foo: string
-  bar: number
 }
-
-
-
 defineProps<Props>()
-
 </script>
 "
 `;
 
-exports[`Common > Interface extends interface > No reference > index.ts (clean newline) 1`] = `
+exports[`Common > Export aliases > Multi level > 2.ts (default) 1`] = `
 "<script lang=\\"ts\\" setup>
 interface Props {
-  baz: boolean
-
   foo: string
-  bar: number
+}
+defineProps<Props>()
+</script>
+"
+`;
+
+exports[`Common > Import aliases > Default > index.ts (default) 1`] = `
+"<script lang=\\"ts\\" setup>
+type _VTI_TYPE_Foo = number
+interface Props {
+  foo: _VTI_TYPE_Foo
+}
+defineProps<Props>()
+</script>
+"
+`;
+
+exports[`Common > Import aliases > Multi level > index.ts (default) 1`] = `
+"<script lang=\\"ts\\" setup>
+type _VTI_TYPE_Bar = string
+type _VTI_TYPE_Foo = number | _VTI_TYPE_Bar
+interface Props {
+  foo: _VTI_TYPE_Foo
+}
+defineProps<Props>()
+</script>
+"
+`;
+
+exports[`Common > Import export default > Default > 1.ts (default) 1`] = `
+"<script lang=\\"ts\\" setup>
+type _VTI_TYPE_Foo = string
+interface Props {
+  foo: _VTI_TYPE_Foo
+}
+defineProps<Props>()
+</script>
+"
+`;
+
+exports[`Common > Import export default > Multi level > 1.ts (default) 1`] = `
+"<script lang=\\"ts\\" setup>
+interface Props {
+  foo: number
+}
+defineProps<Props>()
+</script>
+"
+`;
+
+exports[`Common > Import export default > Multi level > 2.ts (default) 1`] = `
+"<script lang=\\"ts\\" setup>
+type _VTI_TYPE_Foo = string
+interface Props {
+  foo: _VTI_TYPE_Foo
+}
+defineProps<Props>()
+</script>
+"
+`;
+
+exports[`Common > Import export default > Use aliases > 1.ts (default) 1`] = `
+"<script lang=\\"ts\\" setup>
+type _VTI_TYPE_Foo = string
+interface Props {
+  foo: _VTI_TYPE_Foo
+}
+defineProps<Props>()
+</script>
+"
+`;
+
+exports[`Common > Import export default > Use aliases > 2.ts (default) 1`] = `
+"<script lang=\\"ts\\" setup>
+type _VTI_TYPE_Foo = string
+interface Props {
+  foo: _VTI_TYPE_Foo
+}
+defineProps<Props>()
+</script>
+"
+`;
+
+exports[`Common > Import export default > Use aliases > 3.ts (default) 1`] = `
+"<script lang=\\"ts\\" setup>
+type _VTI_TYPE_Foo = string
+interface Props {
+  foo: _VTI_TYPE_Foo
+}
+defineProps<Props>()
+</script>
+"
+`;
+
+exports[`Common > Interface extends interface > Has reference > 1.ts (default) 1`] = `
+"<script lang=\\"ts\\" setup>
+type _VTI_TYPE_Baz = boolean
+type _VTI_TYPE_Bar = number
+type _VTI_TYPE_Foo = string
+interface Props {
+  baz: _VTI_TYPE_Baz
+  foo: _VTI_TYPE_Foo
+  bar: _VTI_TYPE_Bar
+}
+defineProps<Props>()
+</script>
+"
+`;
+
+exports[`Common > Interface extends interface > Has reference > 2.ts (default) 1`] = `
+"<script lang=\\"ts\\" setup>
+type _VTI_TYPE_Baz = boolean
+interface _VTI_TYPE_BaseProps {
+  baz: _VTI_TYPE_Baz
+}
+type _VTI_TYPE_Bar = number
+type _VTI_TYPE_Foo = string
+interface Props {
+  baz: _VTI_TYPE_Baz
+  foo: _VTI_TYPE_Foo
+  bar: _VTI_TYPE_Bar
+  base: _VTI_TYPE_BaseProps
+}
+defineProps<Props>()
+</script>
+"
+`;
+
+exports[`Common > Interface extends interface > Has reference > 3.ts (default) 1`] = `
+"<script lang=\\"ts\\" setup>
+type _VTI_TYPE_Qux = 'qux'
+type _VTI_TYPE_Baz = boolean
+interface _VTI_TYPE_BaseProps {
+  qux: _VTI_TYPE_Qux
+  baz: _VTI_TYPE_Baz
+}
+type _VTI_TYPE_Bar = number
+type _VTI_TYPE_Foo = string
+interface Props {
+  qux: _VTI_TYPE_Qux
+  baz: _VTI_TYPE_Baz
+  foo: _VTI_TYPE_Foo
+  bar: _VTI_TYPE_Bar
+  base: _VTI_TYPE_BaseProps
 }
 defineProps<Props>()
 </script>
@@ -47,48 +179,6 @@ exports[`Common > Interface extends interface > No reference > index.ts (default
 "<script lang=\\"ts\\" setup>
 interface Props {
   baz: boolean
-
-  foo: string
-  bar: number
-}
-
-
-
-defineProps<Props>()
-
-</script>
-"
-`;
-
-exports[`Common > Interface without reference > Default > index.ts (clean all) 1`] = `
-"<script lang=\\"ts\\" setup>
-interface Props {
-  foo: string
-  bar: number
-}
-defineProps<Props>()
-</script>
-"
-`;
-
-exports[`Common > Interface without reference > Default > index.ts (clean interface) 1`] = `
-"<script lang=\\"ts\\" setup>
-interface Props {
-  foo: string
-  bar: number
-}
-
-
-
-defineProps<Props>()
-
-</script>
-"
-`;
-
-exports[`Common > Interface without reference > Default > index.ts (clean newline) 1`] = `
-"<script lang=\\"ts\\" setup>
-interface Props {
   foo: string
   bar: number
 }
@@ -103,49 +193,46 @@ interface Props {
   foo: string
   bar: number
 }
-
-
-
 defineProps<Props>()
-
 </script>
 "
 `;
 
-exports[`Common > Redeclaration of types > Default > index.ts (clean all) 1`] = `
+exports[`Common > Mixed aliases > Default > index.ts (default) 1`] = `
 "<script lang=\\"ts\\" setup>
-type Foo = [number, number]
+type _VTI_TYPE_F = 'A'
 interface Props {
-  foo: Foo
-  bar: Foo
+  foo: _VTI_TYPE_F
 }
 defineProps<Props>()
 </script>
 "
 `;
 
-exports[`Common > Redeclaration of types > Default > index.ts (clean interface) 1`] = `
+exports[`Common > Multi level reference > Default > 1.ts (default) 1`] = `
 "<script lang=\\"ts\\" setup>
-type Foo = [number, number]
+type _VTI_TYPE_Foo = number
+type _VTI_TYPE_Bar = _VTI_TYPE_Foo
 interface Props {
-  foo: Foo
-  bar: Foo
+  foo: _VTI_TYPE_Foo
+  bar: _VTI_TYPE_Bar
 }
-
-
-
 defineProps<Props>()
-
 </script>
 "
 `;
 
-exports[`Common > Redeclaration of types > Default > index.ts (clean newline) 1`] = `
+exports[`Common > Multi level reference > Default > 2.ts (default) 1`] = `
 "<script lang=\\"ts\\" setup>
-type Foo = [number, number]
+type _VTI_TYPE_Foo = number
+type _VTI_TYPE_Bar = _VTI_TYPE_Foo
+type _VTI_TYPE_Qux = _VTI_TYPE_Foo
+type _VTI_TYPE_Baz = _VTI_TYPE_Bar
 interface Props {
-  foo: Foo
-  bar: Foo
+  foo: _VTI_TYPE_Foo
+  bar: _VTI_TYPE_Bar
+  baz: _VTI_TYPE_Baz
+  qux: _VTI_TYPE_Qux
 }
 defineProps<Props>()
 </script>
@@ -154,16 +241,22 @@ defineProps<Props>()
 
 exports[`Common > Redeclaration of types > Default > index.ts (default) 1`] = `
 "<script lang=\\"ts\\" setup>
-type Foo = [number, number]
+type _VTI_TYPE_Foo = [number, number]
 interface Props {
-  foo: Foo
-  bar: Foo
+  foo: _VTI_TYPE_Foo
+  bar: _VTI_TYPE_Foo
 }
-
-
-
 defineProps<Props>()
+</script>
+"
+`;
 
+exports[`Common > Strict type finding > Default > index.ts (default) 1`] = `
+"<script lang=\\"ts\\" setup>
+interface Props {
+  bar: string
+}
+defineProps<Props>()
 </script>
 "
 `;

--- a/test/__snapshots__/common.test.ts.snap
+++ b/test/__snapshots__/common.test.ts.snap
@@ -251,6 +251,20 @@ defineProps<Props>()
 "
 `;
 
+exports[`Common > Redeclaration of types > Same name > index.ts (default) 1`] = `
+"<script lang=\\"ts\\" setup>
+type _VTI_TYPE_Foo_2 = 'foo_2'
+type _VTI_TYPE_Bar = _VTI_TYPE_Foo_2
+type _VTI_TYPE_Foo = 'foo'
+interface Props {
+  foo: _VTI_TYPE_Foo
+  bar: _VTI_TYPE_Bar
+}
+defineProps<Props>()
+</script>
+"
+`;
+
 exports[`Common > Strict type finding > Default > index.ts (default) 1`] = `
 "<script lang=\\"ts\\" setup>
 interface Props {

--- a/test/__snapshots__/dynamic.test.ts.snap
+++ b/test/__snapshots__/dynamic.test.ts.snap
@@ -1,44 +1,100 @@
 // Vitest Snapshot v1
 
-exports[`Dynamic > Interface extends interface > No reference > index.vue (clean all) 1`] = `
+exports[`Dynamic > Interface extends interface > Has reference > 1.vue (default) 1`] = `
 "<script lang=\\"ts\\" setup>
+type Baz = boolean
+type Bar = number
+type Foo = string
 interface Props {
-  baz: boolean
-
-  foo: string
-  bar: number
+  baz: Baz
+  foo: Foo
+  bar: Bar
 }
 defineProps<Props>()
 </script>
 "
 `;
 
-exports[`Dynamic > Interface extends interface > No reference > index.vue (clean interface) 1`] = `
+exports[`Dynamic > Interface extends interface > Has reference > 2.vue (default) 1`] = `
 "<script lang=\\"ts\\" setup>
-interface Props {
-  baz: boolean
-
-  foo: string
-  bar: number
+type Baz = boolean
+interface BaseProps {
+  baz: Baz
 }
-
-
-
-
-
+type Bar = number
+type Foo = string
+interface Props {
+  baz: Baz
+  foo: Foo
+  bar: Bar
+  base: BaseProps
+}
 defineProps<Props>()
-
 </script>
 "
 `;
 
-exports[`Dynamic > Interface extends interface > No reference > index.vue (clean newline) 1`] = `
+exports[`Dynamic > Interface extends interface > Has reference > 3.vue (default) 1`] = `
 "<script lang=\\"ts\\" setup>
+type Qux = 'qux'
+type Baz = boolean
+interface BaseProps {
+  qux: Qux
+  baz: Baz
+}
+type Bar = number
+type Foo = string
 interface Props {
-  baz: boolean
+  qux: Qux
+  baz: Baz
+  foo: Foo
+  bar: Bar
+  base: BaseProps
+}
+defineProps<Props>()
+</script>
+"
+`;
 
-  foo: string
-  bar: number
+exports[`Dynamic > Interface extends interface > Has reference > external_1.vue (default) 1`] = `
+"<script lang=\\"ts\\" setup>
+type _VTI_TYPE_Baz = boolean
+type Bar = number
+type Foo = string
+interface Props {
+  baz: _VTI_TYPE_Baz
+  foo: Foo
+  bar: Bar
+}
+defineProps<Props>()
+</script>
+"
+`;
+
+exports[`Dynamic > Interface extends interface > Has reference > external_2.vue (default) 1`] = `
+"<script lang=\\"ts\\" setup>
+interface _VTI_TYPE_BaseProps {}
+type Bar = number
+type Foo = string
+interface Props {
+  foo: Foo
+  bar: Bar
+  base: _VTI_TYPE_BaseProps
+}
+defineProps<Props>()
+</script>
+"
+`;
+
+exports[`Dynamic > Interface extends interface > Has reference > external_3.vue (default) 1`] = `
+"<script lang=\\"ts\\" setup>
+interface _VTI_TYPE_BaseProps {}
+type Bar = number
+type Foo = string
+interface Props {
+  foo: Foo
+  bar: Bar
+  base: _VTI_TYPE_BaseProps
 }
 defineProps<Props>()
 </script>
@@ -49,63 +105,8 @@ exports[`Dynamic > Interface extends interface > No reference > index.vue (defau
 "<script lang=\\"ts\\" setup>
 interface Props {
   baz: boolean
-
   foo: string
   bar: number
-}
-
-
-
-
-
-defineProps<Props>()
-
-</script>
-"
-`;
-
-exports[`Dynamic > Interface extends interface > No reference > internal.vue (clean all) 1`] = `
-"<script lang=\\"ts\\" setup>
-interface Props {
-  baz: boolean
-
-  foo: string
-  bar: number
-}
-defineProps<Props>()
-</script>
-"
-`;
-
-exports[`Dynamic > Interface extends interface > No reference > internal.vue (clean interface) 1`] = `
-"<script lang=\\"ts\\" setup>
-interface Props {
-  baz: boolean
-
-  foo: string
-  bar: number
-}
-
-
-
-
-
-defineProps<Props>()
-
-</script>
-"
-`;
-
-exports[`Dynamic > Interface extends interface > No reference > internal.vue (clean newline) 1`] = `
-"<script lang=\\"ts\\" setup>
-interface Props {
-  baz: boolean
-
-  foo: string
-  bar: number
-}
-interface BaseProps {
-  baz: boolean
 }
 defineProps<Props>()
 </script>
@@ -116,54 +117,9 @@ exports[`Dynamic > Interface extends interface > No reference > internal.vue (de
 "<script lang=\\"ts\\" setup>
 interface Props {
   baz: boolean
-
   foo: string
   bar: number
 }
-
-interface BaseProps {
-  baz: boolean
-}
-
-
-
-defineProps<Props>()
-
-</script>
-"
-`;
-
-exports[`Dynamic > Interface without reference > No transform > index.vue (clean all) 1`] = `
-"<script lang=\\"ts\\" setup>
-interface Props {
-  foo: string
-  bar: number
-}
-
-defineProps<Props>()
-</script>
-"
-`;
-
-exports[`Dynamic > Interface without reference > No transform > index.vue (clean interface) 1`] = `
-"<script lang=\\"ts\\" setup>
-interface Props {
-  foo: string
-  bar: number
-}
-
-defineProps<Props>()
-</script>
-"
-`;
-
-exports[`Dynamic > Interface without reference > No transform > index.vue (clean newline) 1`] = `
-"<script lang=\\"ts\\" setup>
-interface Props {
-  foo: string
-  bar: number
-}
-
 defineProps<Props>()
 </script>
 "
@@ -175,7 +131,36 @@ interface Props {
   foo: string
   bar: number
 }
+defineProps<Props>()
+</script>
+"
+`;
 
+exports[`Dynamic > Multi level reference > Default > 1.vue (default) 1`] = `
+"<script lang=\\"ts\\" setup>
+type Foo = number
+type Bar = Foo
+interface Props {
+  foo: Foo
+  bar: Bar
+}
+defineProps<Props>()
+</script>
+"
+`;
+
+exports[`Dynamic > Multi level reference > Default > 2.vue (default) 1`] = `
+"<script lang=\\"ts\\" setup>
+type Foo = number
+type Bar = Foo
+type Qux = Foo
+type Baz = Bar
+interface Props {
+  foo: Foo
+  bar: Bar
+  baz: Baz
+  qux: Qux
+}
 defineProps<Props>()
 </script>
 "

--- a/test/_presets.ts
+++ b/test/_presets.ts
@@ -1,12 +1,13 @@
 import type { TransformOptions } from '../src/core'
 
-export type Presets = Record<string, TransformOptions>
+export const presetNames = ['default'] as const
+
+export type PresetNames = typeof presetNames[number]
+
+export type Presets = Record<PresetNames, TransformOptions>
 
 export function generatePresets(id: string): Presets {
   return {
-    'default': { id, clean: {} },
-    'clean newline': { id, clean: { newline: true } },
-    'clean interface': { id, clean: { interface: true } },
-    'clean all': { id, clean: { newline: true, interface: true } },
+    default: { id },
   }
 }

--- a/test/common.test.ts
+++ b/test/common.test.ts
@@ -13,4 +13,5 @@ defineTransformTest({
   filePattern: ['./fixtures/common/**/!(_)*.ts'],
   fileName: __filename,
   codeGetter,
+  skip: false,
 })

--- a/test/dynamic.test.ts
+++ b/test/dynamic.test.ts
@@ -14,4 +14,5 @@ defineTransformTest({
   codeGetter,
   structureRE,
   realPath: true,
+  skip: false,
 })

--- a/test/fixtures/common/export-aliases/default/_types.ts
+++ b/test/fixtures/common/export-aliases/default/_types.ts
@@ -1,0 +1,3 @@
+type F = string
+
+export { F as Foo }

--- a/test/fixtures/common/export-aliases/default/index.ts
+++ b/test/fixtures/common/export-aliases/default/index.ts
@@ -1,0 +1,5 @@
+import type { Foo } from './_types'
+
+export interface Props {
+  foo: Foo
+}

--- a/test/fixtures/common/export-aliases/multi-level/1.ts
+++ b/test/fixtures/common/export-aliases/multi-level/1.ts
@@ -1,0 +1,3 @@
+import { Props } from './types/1'
+
+export { Props }

--- a/test/fixtures/common/export-aliases/multi-level/2.ts
+++ b/test/fixtures/common/export-aliases/multi-level/2.ts
@@ -1,0 +1,1 @@
+export { Props } from './types/1'

--- a/test/fixtures/common/export-aliases/multi-level/types/1.ts
+++ b/test/fixtures/common/export-aliases/multi-level/types/1.ts
@@ -1,0 +1,5 @@
+interface P {
+  foo: string
+}
+
+export { P as Props }

--- a/test/fixtures/common/import-aliases/default/_types.ts
+++ b/test/fixtures/common/import-aliases/default/_types.ts
@@ -1,0 +1,1 @@
+export type F = number

--- a/test/fixtures/common/import-aliases/default/index.ts
+++ b/test/fixtures/common/import-aliases/default/index.ts
@@ -1,0 +1,5 @@
+import type { F as Foo } from './_types'
+
+export interface Props {
+  foo: Foo
+}

--- a/test/fixtures/common/import-aliases/multi-level/_type_A.ts
+++ b/test/fixtures/common/import-aliases/multi-level/_type_A.ts
@@ -1,0 +1,3 @@
+import type { B as Bar } from './_type_B'
+
+export type F = number | Bar

--- a/test/fixtures/common/import-aliases/multi-level/_type_B.ts
+++ b/test/fixtures/common/import-aliases/multi-level/_type_B.ts
@@ -1,0 +1,1 @@
+export type B = string

--- a/test/fixtures/common/import-aliases/multi-level/index.ts
+++ b/test/fixtures/common/import-aliases/multi-level/index.ts
@@ -1,0 +1,5 @@
+import type { F as Foo } from './_type_A'
+
+export interface Props {
+  foo: Foo
+}

--- a/test/fixtures/common/import-export-default/default/1.ts
+++ b/test/fixtures/common/import-export-default/default/1.ts
@@ -1,0 +1,5 @@
+import type Foo from './_types'
+
+export interface Props {
+  foo: Foo
+}

--- a/test/fixtures/common/import-export-default/default/_types.ts
+++ b/test/fixtures/common/import-export-default/default/_types.ts
@@ -1,0 +1,3 @@
+type Foo = string
+
+export default Foo

--- a/test/fixtures/common/import-export-default/multi-level/1.ts
+++ b/test/fixtures/common/import-export-default/multi-level/1.ts
@@ -1,0 +1,3 @@
+import Props from './types/1'
+
+export { Props }

--- a/test/fixtures/common/import-export-default/multi-level/2.ts
+++ b/test/fixtures/common/import-export-default/multi-level/2.ts
@@ -1,0 +1,5 @@
+import type Foo from './types/2'
+
+export interface Props {
+  foo: Foo
+}

--- a/test/fixtures/common/import-export-default/multi-level/types/1.ts
+++ b/test/fixtures/common/import-export-default/multi-level/types/1.ts
@@ -1,0 +1,5 @@
+export interface Props {
+  foo: number
+}
+
+export default Props

--- a/test/fixtures/common/import-export-default/multi-level/types/2.ts
+++ b/test/fixtures/common/import-export-default/multi-level/types/2.ts
@@ -1,0 +1,1 @@
+export { default } from './3'

--- a/test/fixtures/common/import-export-default/multi-level/types/3.ts
+++ b/test/fixtures/common/import-export-default/multi-level/types/3.ts
@@ -1,0 +1,3 @@
+type Foo = string
+
+export default Foo

--- a/test/fixtures/common/import-export-default/use-aliases/1.ts
+++ b/test/fixtures/common/import-export-default/use-aliases/1.ts
@@ -1,0 +1,5 @@
+import type Foo from './types/alias'
+
+export interface Props {
+  foo: Foo
+}

--- a/test/fixtures/common/import-export-default/use-aliases/2.ts
+++ b/test/fixtures/common/import-export-default/use-aliases/2.ts
@@ -1,0 +1,6 @@
+/* eslint-disable import/no-named-default */
+import type { default as Foo } from './types/default'
+
+export interface Props {
+  foo: Foo
+}

--- a/test/fixtures/common/import-export-default/use-aliases/3.ts
+++ b/test/fixtures/common/import-export-default/use-aliases/3.ts
@@ -1,0 +1,6 @@
+/* eslint-disable import/no-named-default */
+import type { default as Foo } from './types/alias'
+
+export interface Props {
+  foo: Foo
+}

--- a/test/fixtures/common/import-export-default/use-aliases/types/alias.ts
+++ b/test/fixtures/common/import-export-default/use-aliases/types/alias.ts
@@ -1,0 +1,3 @@
+type Foo = string
+
+export { Foo as default }

--- a/test/fixtures/common/import-export-default/use-aliases/types/default.ts
+++ b/test/fixtures/common/import-export-default/use-aliases/types/default.ts
@@ -1,0 +1,3 @@
+type Foo = string
+
+export default Foo

--- a/test/fixtures/common/interface-extends-interface/has-reference/1.ts
+++ b/test/fixtures/common/interface-extends-interface/has-reference/1.ts
@@ -1,0 +1,14 @@
+type Baz = boolean
+
+type Bar = number
+
+type Foo = string
+
+export interface BaseProps {
+  baz: Baz
+}
+
+export interface Props extends BaseProps {
+  foo: Foo
+  bar: Bar
+}

--- a/test/fixtures/common/interface-extends-interface/has-reference/2.ts
+++ b/test/fixtures/common/interface-extends-interface/has-reference/2.ts
@@ -1,0 +1,15 @@
+type Baz = boolean
+
+type Bar = number
+
+type Foo = string
+
+export interface BaseProps {
+  baz: Baz
+}
+
+export interface Props extends BaseProps {
+  foo: Foo
+  bar: Bar
+  base: BaseProps
+}

--- a/test/fixtures/common/interface-extends-interface/has-reference/3.ts
+++ b/test/fixtures/common/interface-extends-interface/has-reference/3.ts
@@ -1,0 +1,21 @@
+type Baz = boolean
+
+type Bar = number
+
+type Foo = string
+
+type Qux = 'qux'
+
+interface Base {
+  qux: Qux
+}
+
+export interface BaseProps extends Base {
+  baz: Baz
+}
+
+export interface Props extends BaseProps {
+  foo: Foo
+  bar: Bar
+  base: BaseProps
+}

--- a/test/fixtures/common/interface-extends-interface/no-reference/_other_type.ts
+++ b/test/fixtures/common/interface-extends-interface/no-reference/_other_type.ts
@@ -1,1 +1,0 @@
-// This file will not be treated as an entry file

--- a/test/fixtures/common/mixed-aliases/default/index.ts
+++ b/test/fixtures/common/mixed-aliases/default/index.ts
@@ -1,0 +1,5 @@
+import type { Foo as F } from './types/1'
+
+export interface Props {
+  foo: F
+}

--- a/test/fixtures/common/mixed-aliases/default/types/1.ts
+++ b/test/fixtures/common/mixed-aliases/default/types/1.ts
@@ -1,0 +1,3 @@
+import { A as F } from './2'
+
+export { F as Foo }

--- a/test/fixtures/common/mixed-aliases/default/types/2.ts
+++ b/test/fixtures/common/mixed-aliases/default/types/2.ts
@@ -1,0 +1,3 @@
+type B = 'A'
+
+export { B as A }

--- a/test/fixtures/common/multi-level-reference/default/1.ts
+++ b/test/fixtures/common/multi-level-reference/default/1.ts
@@ -1,0 +1,8 @@
+type Foo = number
+
+type Bar = Foo
+
+export interface Props {
+  foo: Foo
+  bar: Bar
+}

--- a/test/fixtures/common/multi-level-reference/default/2.ts
+++ b/test/fixtures/common/multi-level-reference/default/2.ts
@@ -1,0 +1,14 @@
+type Foo = number
+
+type Bar = Foo
+
+type Baz = Bar
+
+type Qux = Foo
+
+export interface Props {
+  foo: Foo
+  bar: Bar
+  baz: Baz
+  qux: Qux
+}

--- a/test/fixtures/common/redeclaration-of-types/same-name/_type.ts
+++ b/test/fixtures/common/redeclaration-of-types/same-name/_type.ts
@@ -1,0 +1,3 @@
+type Foo = 'foo_2'
+
+export type Bar = Foo

--- a/test/fixtures/common/redeclaration-of-types/same-name/index.ts
+++ b/test/fixtures/common/redeclaration-of-types/same-name/index.ts
@@ -1,0 +1,8 @@
+import type { Bar } from './_type'
+
+type Foo = 'foo'
+
+export interface Props {
+  foo: Foo
+  bar: Bar
+}

--- a/test/fixtures/common/strict-type-finding/default/_types.ts
+++ b/test/fixtures/common/strict-type-finding/default/_types.ts
@@ -1,0 +1,3 @@
+export interface Props {
+  bar: string
+}

--- a/test/fixtures/common/strict-type-finding/default/index.ts
+++ b/test/fixtures/common/strict-type-finding/default/index.ts
@@ -1,0 +1,6 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+interface Props {
+  foo: number
+}
+
+export { Props } from './_types'

--- a/test/fixtures/dynamic/interface-extends-interface/has-reference/1.vue
+++ b/test/fixtures/dynamic/interface-extends-interface/has-reference/1.vue
@@ -1,0 +1,18 @@
+<script lang="ts" setup>
+type Baz = boolean
+
+type Bar = number
+
+type Foo = string
+
+interface BaseProps {
+  baz: Baz
+}
+
+interface Props extends BaseProps {
+  foo: Foo
+  bar: Bar
+}
+
+defineProps<Props>()
+</script>

--- a/test/fixtures/dynamic/interface-extends-interface/has-reference/2.vue
+++ b/test/fixtures/dynamic/interface-extends-interface/has-reference/2.vue
@@ -1,0 +1,19 @@
+<script lang="ts" setup>
+type Baz = boolean
+
+type Bar = number
+
+type Foo = string
+
+interface BaseProps {
+  baz: Baz
+}
+
+interface Props extends BaseProps {
+  foo: Foo
+  bar: Bar
+  base: BaseProps
+}
+
+defineProps<Props>()
+</script>

--- a/test/fixtures/dynamic/interface-extends-interface/has-reference/3.vue
+++ b/test/fixtures/dynamic/interface-extends-interface/has-reference/3.vue
@@ -1,0 +1,25 @@
+<script lang="ts" setup>
+type Baz = boolean
+
+type Bar = number
+
+type Foo = string
+
+type Qux = 'qux'
+
+interface Base {
+  qux: Qux
+}
+
+interface BaseProps extends Base {
+  baz: Baz
+}
+
+interface Props extends BaseProps {
+  foo: Foo
+  bar: Bar
+  base: BaseProps
+}
+
+defineProps<Props>()
+</script>

--- a/test/fixtures/dynamic/interface-extends-interface/has-reference/external_1.vue
+++ b/test/fixtures/dynamic/interface-extends-interface/has-reference/external_1.vue
@@ -1,0 +1,14 @@
+<script lang="ts" setup>
+import type { BaseProps } from './externals/1'
+
+type Bar = number
+
+type Foo = string
+
+interface Props extends BaseProps {
+  foo: Foo
+  bar: Bar
+}
+
+defineProps<Props>()
+</script>

--- a/test/fixtures/dynamic/interface-extends-interface/has-reference/external_2.vue
+++ b/test/fixtures/dynamic/interface-extends-interface/has-reference/external_2.vue
@@ -1,0 +1,15 @@
+<script lang="ts" setup>
+import type { BaseProps } from './externals/2'
+
+type Bar = number
+
+type Foo = string
+
+interface Props extends BaseProps {
+  foo: Foo
+  bar: Bar
+  base: BaseProps
+}
+
+defineProps<Props>()
+</script>

--- a/test/fixtures/dynamic/interface-extends-interface/has-reference/external_3.vue
+++ b/test/fixtures/dynamic/interface-extends-interface/has-reference/external_3.vue
@@ -1,0 +1,15 @@
+<script lang="ts" setup>
+import type { BaseProps } from './externals/3'
+
+type Bar = number
+
+type Foo = string
+
+interface Props extends BaseProps {
+  foo: Foo
+  bar: Bar
+  base: BaseProps
+}
+
+defineProps<Props>()
+</script>

--- a/test/fixtures/dynamic/interface-extends-interface/has-reference/externals/1.ts
+++ b/test/fixtures/dynamic/interface-extends-interface/has-reference/externals/1.ts
@@ -1,0 +1,5 @@
+type Baz = boolean
+
+export interface BaseProps {
+  baz: Baz
+}

--- a/test/fixtures/dynamic/interface-extends-interface/has-reference/externals/2.ts
+++ b/test/fixtures/dynamic/interface-extends-interface/has-reference/externals/2.ts
@@ -1,0 +1,5 @@
+type Baz = boolean
+
+export interface BaseProps {
+  baz: Baz
+}

--- a/test/fixtures/dynamic/interface-extends-interface/has-reference/externals/3.ts
+++ b/test/fixtures/dynamic/interface-extends-interface/has-reference/externals/3.ts
@@ -1,0 +1,11 @@
+type Baz = boolean
+
+type Qux = 'qux'
+
+interface Base {
+  qux: Qux
+}
+
+export interface BaseProps extends Base {
+  baz: Baz
+}

--- a/test/fixtures/dynamic/multi-level-reference/default/1.vue
+++ b/test/fixtures/dynamic/multi-level-reference/default/1.vue
@@ -1,0 +1,12 @@
+<script lang="ts" setup>
+type Bar = Foo
+
+type Foo = number
+
+interface Props {
+  foo: Foo
+  bar: Bar
+}
+
+defineProps<Props>()
+</script>

--- a/test/fixtures/dynamic/multi-level-reference/default/2.vue
+++ b/test/fixtures/dynamic/multi-level-reference/default/2.vue
@@ -1,0 +1,18 @@
+<script lang="ts" setup>
+type Foo = number
+
+type Bar = Foo
+
+type Baz = Bar
+
+type Qux = Foo
+
+interface Props {
+  foo: Foo
+  bar: Bar
+  baz: Baz
+  qux: Qux
+}
+
+defineProps<Props>()
+</script>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,9 +8,10 @@
     "strict": true,
     "strictNullChecks": true,
     "resolveJsonModule": true,
+    "skipLibCheck": true,
     "skipDefaultLibCheck": true,
     "skipLibCheck": true,
-    "types": ["vitest/globals"],
+    "types": ["vitest/globals", "vitest/importMeta"],
     "forceConsistentCasingInFileNames": true
   },
   "exclude": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,6 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
-    "skipLibCheck": true,
     "types": ["vitest/globals", "vitest/importMeta"],
     "forceConsistentCasingInFileNames": true
   },

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -3,6 +3,9 @@ import { defineConfig } from 'tsup'
 const isProduction = process.env.NODE_ENV === 'production'
 
 export default defineConfig({
+  define: {
+    'import.meta.vitest': 'undefined',
+  },
   minify: true,
   format: ['esm', 'cjs'],
   entry: ['./src/index.ts', './src/nuxt.ts'],


### PR DESCRIPTION
## Description

### BREAKING CHANGES
Remove option `clean` because the architecture of the plugin has changed in this PR, I don't think they are needed.
(Of course, we can add it back if any users want this feature.)

And now the plugin has no options again so I remove the corresponding type definition.

### Features
Support the following import/export syntaxes:
- `import { a as b }` (import aliases)
- `import default` (default specifier of ImportDeclaration)
- `export { a as b }` (export aliases)
- `export default` (default specifier of ExportNamedDeclaration)

### Bug fixes
- Inline order of type aliases
- Missing type when import (explicitly/implicitly) types with same name but from different sources
- Add prefix for types to avoid redeclaration of types
- Stricter type finding
- Missing props when an interface is both extended and referenced (multiple extends)
- Newlines cleaning on windows platform

### Other changes
- Update dependencies to the latest version
- Update nuxt module definition
- Add package `debug` for debugging
- Add package `picocolors` to colorize logs