### PR TITLE
fix: improve the way of handling same type

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ defineProps<User>()
 - The plugin may be slow because it needs to read files and traverse the AST (using @babel/parser).
 
 ## Caveats
-**Do not reference the types themselves implicitly, it will cause infinite loop**.
+- **Do not reference the types themselves implicitly, it will cause infinite loop**.
 Vue will also get wrong type definition even if you disable this plugin.
 
 Illegal code:
@@ -98,6 +98,14 @@ export interface Foo {
   foo: Foo
   bar: Foo | Bar
 }
+```
+
+- Ending the type name with something like `_1` and `_2` is not recommended, because it may **conflict** with the plugin's transformation result
+
+These types may cause conflicts:
+```ts
+type Foo_1 = string
+type Bar_2 = number
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -77,23 +77,27 @@ defineProps<User>()
 - The plugin may be slow because it needs to read files and traverse the AST (using @babel/parser).
 
 ## Caveats
-It is not recommended to write **duplicate** imports/exports. It may affect the result of the plugin's transformation. You will get warnings if the plugin detects this kind of code.
+**Do not reference the types themselves implicitly, it will cause infinite loop**.
+Vue will also get wrong type definition even if you disable this plugin.
 
-Examples:
+Illegal code:
+```ts
+export type Bar = Foo
+export interface Foo {
+  foo: Bar
+}
+```
 
-```javascript
-// These kinds of code will trigger warnings from the plugin
-import { Foo, Foo as Bar } from 'foo'
+Alternatively, you can reference the types themselves in their own definitions
 
-import { Foo as Bar, Foo as Baz } from 'foo'
+Acceptable code:
+```ts
+export type Bar = string
 
-export { Foo, Foo as Bar }
-
-export { Foo as Bar, Foo as Baz }
-
-export { Foo, Foo as Bar } from 'foo'
-
-export { Foo as Bar, Foo as Baz } from 'foo'
+export interface Foo {
+  foo: Foo
+  bar: Foo | Bar
+}
 ```
 
 ## License

--- a/package.json
+++ b/package.json
@@ -38,32 +38,32 @@
   },
   "keywords": [],
   "devDependencies": {
-    "@antfu/eslint-config": "^0.26.2",
-    "@antfu/ni": "^0.17.2",
+    "@antfu/eslint-config": "^0.26.3",
+    "@antfu/ni": "^0.18.0",
     "@types/debug": "^4.1.7",
-    "@types/node": "^18.7.14",
-    "@vitest/coverage-c8": "^0.22.1",
-    "@vitest/ui": "^0.22.1",
-    "@vue/compiler-sfc": "^3.2.38",
+    "@types/node": "^18.7.16",
+    "@vitest/coverage-c8": "^0.23.1",
+    "@vitest/ui": "^0.23.1",
+    "@vue/compiler-sfc": "^3.2.39",
     "bumpp": "^8.2.1",
     "cross-env": "^7.0.3",
     "eslint": "^8.23.0",
     "esno": "^0.16.3",
     "git-ensure": "^0.1.0",
     "tsup": "6.2.3",
-    "typescript": "^4.8.2",
-    "vite": "^3.0.9",
-    "vitest": "^0.22.1",
-    "vue": "^3.2.38"
+    "typescript": "^4.8.3",
+    "vite": "^3.1.0",
+    "vitest": "^0.23.1",
+    "vue": "^3.2.39"
   },
   "peerDependencies": {
     "@vue/compiler-sfc": "^3.2.24",
     "vue": "^3.2.24"
   },
   "dependencies": {
-    "@babel/types": "^7.18.13",
+    "@babel/types": "^7.19.0",
     "debug": "^4.3.4",
-    "fast-glob": "^3.2.11",
+    "fast-glob": "^3.2.12",
     "local-pkg": "^0.4.2",
     "picocolors": "^1.0.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,52 +4,52 @@ importers:
 
   .:
     specifiers:
-      '@antfu/eslint-config': ^0.26.2
-      '@antfu/ni': ^0.17.2
-      '@babel/types': ^7.18.13
+      '@antfu/eslint-config': ^0.26.3
+      '@antfu/ni': ^0.18.0
+      '@babel/types': ^7.19.0
       '@types/debug': ^4.1.7
-      '@types/node': ^18.7.14
-      '@vitest/coverage-c8': ^0.22.1
-      '@vitest/ui': ^0.22.1
-      '@vue/compiler-sfc': ^3.2.38
+      '@types/node': ^18.7.16
+      '@vitest/coverage-c8': ^0.23.1
+      '@vitest/ui': ^0.23.1
+      '@vue/compiler-sfc': ^3.2.39
       bumpp: ^8.2.1
       cross-env: ^7.0.3
       debug: ^4.3.4
       eslint: ^8.23.0
       esno: ^0.16.3
-      fast-glob: ^3.2.11
+      fast-glob: ^3.2.12
       git-ensure: ^0.1.0
       local-pkg: ^0.4.2
       picocolors: ^1.0.0
       tsup: 6.2.3
-      typescript: ^4.8.2
-      vite: ^3.0.9
-      vitest: ^0.22.1
-      vue: ^3.2.38
+      typescript: ^4.8.3
+      vite: ^3.1.0
+      vitest: ^0.23.1
+      vue: ^3.2.39
     dependencies:
-      '@babel/types': 7.18.13
+      '@babel/types': 7.19.0
       debug: 4.3.4
-      fast-glob: 3.2.11
+      fast-glob: 3.2.12
       local-pkg: 0.4.2
       picocolors: 1.0.0
     devDependencies:
-      '@antfu/eslint-config': 0.26.2_yqf6kl63nyoq5megxukfnom5rm
-      '@antfu/ni': 0.17.2
+      '@antfu/eslint-config': 0.26.3_itqs5654cmlnjraw6gjzqacppi
+      '@antfu/ni': 0.18.0
       '@types/debug': 4.1.7
-      '@types/node': 18.7.14
-      '@vitest/coverage-c8': 0.22.1_@vitest+ui@0.22.1
-      '@vitest/ui': 0.22.1
-      '@vue/compiler-sfc': 3.2.38
+      '@types/node': 18.7.16
+      '@vitest/coverage-c8': 0.23.1_@vitest+ui@0.23.1
+      '@vitest/ui': 0.23.1
+      '@vue/compiler-sfc': 3.2.39
       bumpp: 8.2.1
       cross-env: 7.0.3
       eslint: 8.23.0
       esno: 0.16.3
       git-ensure: 0.1.0
-      tsup: 6.2.3_typescript@4.8.2
-      typescript: 4.8.2
-      vite: 3.0.9
-      vitest: 0.22.1_@vitest+ui@0.22.1
-      vue: 3.2.38
+      tsup: 6.2.3_typescript@4.8.3
+      typescript: 4.8.3
+      vite: 3.1.0
+      vitest: 0.23.1_@vitest+ui@0.23.1
+      vue: 3.2.39
 
   playground:
     specifiers:
@@ -92,22 +92,22 @@ packages:
       '@jridgewell/trace-mapping': 0.3.14
     dev: true
 
-  /@antfu/eslint-config-basic/0.26.2_3g5q5capxpyhialyvs33l4nssm:
-    resolution: {integrity: sha512-wPaKvRhymhaWhaJq4b/CiYnsZ/jONr7wVHy801p6kwUzUvekyY8ZAhU60YoDpb2J8Mh06268b0nHUlULgvMJAw==}
+  /@antfu/eslint-config-basic/0.26.3_2l2r3i3lm6jysqd4ac3ql4n2mm:
+    resolution: {integrity: sha512-IgJPYGMmNb6/99Iqg8huiT8qs6lFLu794a97lzwQoHTtLoBYx6VFSfM6tXrsOCnRyrdX5DwfGPnOrxVelbcAFQ==}
     peerDependencies:
       eslint: '>=7.4.0'
     dependencies:
       eslint: 8.23.0
-      eslint-plugin-antfu: 0.26.2_yqf6kl63nyoq5megxukfnom5rm
+      eslint-plugin-antfu: 0.26.3_itqs5654cmlnjraw6gjzqacppi
       eslint-plugin-eslint-comments: 3.2.0_eslint@8.23.0
       eslint-plugin-html: 7.1.0
-      eslint-plugin-import: 2.26.0_en2wbs6aggmxy4drejzsyh4gce
+      eslint-plugin-import: 2.26.0_iepzrjnvahcxaf6zc7cutko6om
       eslint-plugin-jsonc: 2.4.0_eslint@8.23.0
       eslint-plugin-markdown: 3.0.0_eslint@8.23.0
       eslint-plugin-n: 15.2.5_eslint@8.23.0
       eslint-plugin-promise: 6.0.1_eslint@8.23.0
       eslint-plugin-unicorn: 43.0.2_eslint@8.23.0
-      eslint-plugin-yml: 1.1.0_eslint@8.23.0
+      eslint-plugin-yml: 1.2.0_eslint@8.23.0
       jsonc-eslint-parser: 2.1.0
       yaml-eslint-parser: 1.1.0
     transitivePeerDependencies:
@@ -118,14 +118,14 @@ packages:
       - typescript
     dev: true
 
-  /@antfu/eslint-config-react/0.26.2_yqf6kl63nyoq5megxukfnom5rm:
-    resolution: {integrity: sha512-/IxXC9mqtcT1MmXpmGLFH24eWSfuhFAezBvWfyDbbFzFFimzb6ud8n9/kidG9A3bTbc/aBfTKd/840aBL9kMhQ==}
+  /@antfu/eslint-config-react/0.26.3_itqs5654cmlnjraw6gjzqacppi:
+    resolution: {integrity: sha512-S4wqID2RW4aiPam9bvtyJGHRo6G+lBBAL6HxLLNF6jC0HjN0ZpkJXHsruqroKm10YexBKnmr6W+iB1NSJROvwQ==}
     peerDependencies:
       eslint: '>=7.4.0'
     dependencies:
-      '@antfu/eslint-config-ts': 0.26.2_yqf6kl63nyoq5megxukfnom5rm
+      '@antfu/eslint-config-ts': 0.26.3_itqs5654cmlnjraw6gjzqacppi
       eslint: 8.23.0
-      eslint-plugin-react: 7.31.1_eslint@8.23.0
+      eslint-plugin-react: 7.31.8_eslint@8.23.0
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -133,29 +133,29 @@ packages:
       - typescript
     dev: true
 
-  /@antfu/eslint-config-ts/0.26.2_yqf6kl63nyoq5megxukfnom5rm:
-    resolution: {integrity: sha512-larpzAjXo565HGxUL8jg3ZDUwQ7kWnt5rdottCuW3grnkVL5PAE3wVvBktnYaPYyLxW/GdrTS6yGSrocCan7Iw==}
+  /@antfu/eslint-config-ts/0.26.3_itqs5654cmlnjraw6gjzqacppi:
+    resolution: {integrity: sha512-MpgdAbhgCQl5JpDjGLGLjI4npp2VpTvdpISdoFkCD03kTcbkvwD4oeoIYCQannFs/pY8xC/JDvehTPd5puhn7A==}
     peerDependencies:
       eslint: '>=7.4.0'
       typescript: '>=3.9'
     dependencies:
-      '@antfu/eslint-config-basic': 0.26.2_3g5q5capxpyhialyvs33l4nssm
-      '@typescript-eslint/eslint-plugin': 5.36.1_3g5q5capxpyhialyvs33l4nssm
-      '@typescript-eslint/parser': 5.36.0_yqf6kl63nyoq5megxukfnom5rm
+      '@antfu/eslint-config-basic': 0.26.3_2l2r3i3lm6jysqd4ac3ql4n2mm
+      '@typescript-eslint/eslint-plugin': 5.36.2_2l2r3i3lm6jysqd4ac3ql4n2mm
+      '@typescript-eslint/parser': 5.36.2_itqs5654cmlnjraw6gjzqacppi
       eslint: 8.23.0
-      typescript: 4.8.2
+      typescript: 4.8.3
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
     dev: true
 
-  /@antfu/eslint-config-vue/0.26.2_yqf6kl63nyoq5megxukfnom5rm:
-    resolution: {integrity: sha512-LcSo+V86f+BSc9eB4YNeAvw3GPQjcWE3wrK6VaOmKSlt4tOewj2usJa5jfhHpSsmdrBOw2ORMKd4+3iyx7bMtQ==}
+  /@antfu/eslint-config-vue/0.26.3_itqs5654cmlnjraw6gjzqacppi:
+    resolution: {integrity: sha512-74lWt8SuOeNbjLE+0iw1JpEJ+SUjO3lt6Gj7MXB5L2foy9Oq/LJrkGi9gS3koC3n6150T3nXTVxURBLatbqLbg==}
     peerDependencies:
       eslint: '>=7.4.0'
     dependencies:
-      '@antfu/eslint-config-ts': 0.26.2_yqf6kl63nyoq5megxukfnom5rm
+      '@antfu/eslint-config-ts': 0.26.3_itqs5654cmlnjraw6gjzqacppi
       eslint: 8.23.0
       eslint-plugin-vue: 9.4.0_eslint@8.23.0
     transitivePeerDependencies:
@@ -165,25 +165,25 @@ packages:
       - typescript
     dev: true
 
-  /@antfu/eslint-config/0.26.2_yqf6kl63nyoq5megxukfnom5rm:
-    resolution: {integrity: sha512-IKnvTP7KJ+nYloYb8qzH1YGr5qvJqGGGq3q443t0TPn+93W0b+mU0T+wOWXimOlYimSes8Chi8/e4DZk7ZQRgg==}
+  /@antfu/eslint-config/0.26.3_itqs5654cmlnjraw6gjzqacppi:
+    resolution: {integrity: sha512-5sQaAPziZegoCEbzjAGzHpYwNBsKVdT+9A4ZWph+dtC/lVw+ORrlhoxY+GrtrNa5GqPyIgpJDWJHFLiKICGdCQ==}
     peerDependencies:
       eslint: '>=7.4.0'
     dependencies:
-      '@antfu/eslint-config-react': 0.26.2_yqf6kl63nyoq5megxukfnom5rm
-      '@antfu/eslint-config-vue': 0.26.2_yqf6kl63nyoq5megxukfnom5rm
-      '@typescript-eslint/eslint-plugin': 5.36.1_3g5q5capxpyhialyvs33l4nssm
-      '@typescript-eslint/parser': 5.36.0_yqf6kl63nyoq5megxukfnom5rm
+      '@antfu/eslint-config-react': 0.26.3_itqs5654cmlnjraw6gjzqacppi
+      '@antfu/eslint-config-vue': 0.26.3_itqs5654cmlnjraw6gjzqacppi
+      '@typescript-eslint/eslint-plugin': 5.36.2_2l2r3i3lm6jysqd4ac3ql4n2mm
+      '@typescript-eslint/parser': 5.36.2_itqs5654cmlnjraw6gjzqacppi
       eslint: 8.23.0
       eslint-plugin-eslint-comments: 3.2.0_eslint@8.23.0
       eslint-plugin-html: 7.1.0
-      eslint-plugin-import: 2.26.0_en2wbs6aggmxy4drejzsyh4gce
+      eslint-plugin-import: 2.26.0_iepzrjnvahcxaf6zc7cutko6om
       eslint-plugin-jsonc: 2.4.0_eslint@8.23.0
       eslint-plugin-n: 15.2.5_eslint@8.23.0
       eslint-plugin-promise: 6.0.1_eslint@8.23.0
       eslint-plugin-unicorn: 43.0.2_eslint@8.23.0
       eslint-plugin-vue: 9.4.0_eslint@8.23.0
-      eslint-plugin-yml: 1.1.0_eslint@8.23.0
+      eslint-plugin-yml: 1.2.0_eslint@8.23.0
       jsonc-eslint-parser: 2.1.0
       yaml-eslint-parser: 1.1.0
     transitivePeerDependencies:
@@ -200,8 +200,8 @@ packages:
       find-up: 5.0.0
     dev: true
 
-  /@antfu/ni/0.17.2:
-    resolution: {integrity: sha512-uYsmcsQzylpMiRB4gJRwcEJMIrKyeHZO0CJct8MmqkT3B7HTFU6oSZhDB50E/XvQw7FW8oT/tKsq3NFplRgG2Q==}
+  /@antfu/ni/0.18.0:
+    resolution: {integrity: sha512-D0eek5EV8wOUpZNVAs/mPyeC5TMWFXqchqCyPiR6Lj5FgmSJw0EpFLqAczHX0O5+Jc07N7NBwBip85Gi1MBJnA==}
     hasBin: true
     dev: true
 
@@ -240,12 +240,12 @@ packages:
     dependencies:
       '@babel/types': 7.18.10
 
-  /@babel/parser/7.18.13:
-    resolution: {integrity: sha512-dgXcIfMuQ0kgzLB2b9tRZs7TTFFaGM2AbtA4fJgUUYukzGH4jwsS7hzQHEGs67jdehpm22vkgKwvbU+aEflgwg==}
+  /@babel/parser/7.19.0:
+    resolution: {integrity: sha512-74bEXKX2h+8rrfQUfsBfuZZHzsEs6Eql4pqy/T4Nn6Y9wNPggQOqD6z6pn5Bl8ZfysKouFZT/UXEH94ummEeQw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
-      '@babel/types': 7.18.13
+      '@babel/types': 7.19.0
     dev: true
 
   /@babel/types/7.18.10:
@@ -256,8 +256,8 @@ packages:
       '@babel/helper-validator-identifier': 7.18.6
       to-fast-properties: 2.0.0
 
-  /@babel/types/7.18.13:
-    resolution: {integrity: sha512-ePqfTihzW0W6XAU+aMw2ykilisStJfDnsejDCXRchCcMJ4O0+8DhPXf2YUbZ6wjBlsEmZwLK/sPweWtu8hcJYQ==}
+  /@babel/types/7.19.0:
+    resolution: {integrity: sha512-YuGopBq3ke25BVSiS6fgF49Ul9gH1x70Bcr6bqRLjWCkcX8Hre1/5+z+IiWOIerRMSSEfGZVB9z9kyq7wVs9YA==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-string-parser': 7.18.10
@@ -278,7 +278,7 @@ packages:
   /@esbuild-kit/core-utils/2.3.0:
     resolution: {integrity: sha512-JL73zt/LN/qqziHuod4/bM2xBNNofDZu1cbwT6KIn6B11lA4cgDXkoSHOfNCbZMZOnh0Aqf0vW/gNQC+Z18hKQ==}
     dependencies:
-      esbuild: 0.15.6
+      esbuild: 0.15.7
       source-map-support: 0.5.21
     dev: true
 
@@ -298,17 +298,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-loong64/0.14.54:
-    resolution: {integrity: sha512-bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw==}
-    engines: {node: '>=12'}
-    cpu: [loong64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-loong64/0.15.6:
-    resolution: {integrity: sha512-hqmVU2mUjH6J2ZivHphJ/Pdse2ZD+uGCHK0uvsiLDk/JnSedEVj77CiVUnbMKuU4tih1TZZL8tG9DExQg/GZsw==}
+  /@esbuild/linux-loong64/0.15.7:
+    resolution: {integrity: sha512-IKznSJOsVUuyt7cDzzSZyqBEcZe+7WlBqTVXiF1OXP/4Nm387ToaXZ0fyLwI1iBlI/bzpxVq411QE2/Bt2XWWw==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
@@ -512,8 +503,8 @@ packages:
     resolution: {integrity: sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==}
     dev: true
 
-  /@types/node/18.7.14:
-    resolution: {integrity: sha512-6bbDaETVi8oyIARulOE9qF1/Qdi/23z6emrUh0fNJRUmjznqrixD4MpGDdgOFk5Xb0m2H6Xu42JGdvAxaJR/wA==}
+  /@types/node/18.7.16:
+    resolution: {integrity: sha512-EQHhixfu+mkqHMZl1R2Ovuvn47PUw18azMJOTwSZr9/fhzHNGXAJ0ma0dayRVchprpCj0Kc1K1xKoWaATWF1qg==}
     dev: true
 
   /@types/normalize-package-data/2.4.1:
@@ -527,8 +518,8 @@ packages:
   /@types/web-bluetooth/0.0.15:
     resolution: {integrity: sha512-w7hEHXnPMEZ+4nGKl/KDRVpxkwYxYExuHOYXyzIzCDzEZ9ZCGMAewulr9IqJu2LR4N37fcnb1XVeuZ09qgOxhA==}
 
-  /@typescript-eslint/eslint-plugin/5.36.1_3g5q5capxpyhialyvs33l4nssm:
-    resolution: {integrity: sha512-iC40UK8q1tMepSDwiLbTbMXKDxzNy+4TfPWgIL661Ym0sD42vRcQU93IsZIrmi+x292DBr60UI/gSwfdVYexCA==}
+  /@typescript-eslint/eslint-plugin/5.36.2_2l2r3i3lm6jysqd4ac3ql4n2mm:
+    resolution: {integrity: sha512-OwwR8LRwSnI98tdc2z7mJYgY60gf7I9ZfGjN5EjCwwns9bdTuQfAXcsjSB2wSQ/TVNYSGKf4kzVXbNGaZvwiXw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       '@typescript-eslint/parser': ^5.0.0
@@ -538,24 +529,24 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.36.0_yqf6kl63nyoq5megxukfnom5rm
-      '@typescript-eslint/scope-manager': 5.36.1
-      '@typescript-eslint/type-utils': 5.36.1_yqf6kl63nyoq5megxukfnom5rm
-      '@typescript-eslint/utils': 5.36.1_yqf6kl63nyoq5megxukfnom5rm
+      '@typescript-eslint/parser': 5.36.2_itqs5654cmlnjraw6gjzqacppi
+      '@typescript-eslint/scope-manager': 5.36.2
+      '@typescript-eslint/type-utils': 5.36.2_itqs5654cmlnjraw6gjzqacppi
+      '@typescript-eslint/utils': 5.36.2_itqs5654cmlnjraw6gjzqacppi
       debug: 4.3.4
       eslint: 8.23.0
       functional-red-black-tree: 1.0.1
       ignore: 5.2.0
       regexpp: 3.2.0
       semver: 7.3.7
-      tsutils: 3.21.0_typescript@4.8.2
-      typescript: 4.8.2
+      tsutils: 3.21.0_typescript@4.8.3
+      typescript: 4.8.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/5.36.0_yqf6kl63nyoq5megxukfnom5rm:
-    resolution: {integrity: sha512-dlBZj7EGB44XML8KTng4QM0tvjI8swDh8MdpE5NX5iHWgWEfIuqSfSE+GPeCrCdj7m4tQLuevytd57jNDXJ2ZA==}
+  /@typescript-eslint/parser/5.36.2_itqs5654cmlnjraw6gjzqacppi:
+    resolution: {integrity: sha512-qS/Kb0yzy8sR0idFspI9Z6+t7mqk/oRjnAYfewG+VN73opAUvmYL3oPIMmgOX6CnQS6gmVIXGshlb5RY/R22pA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -564,34 +555,26 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/scope-manager': 5.36.0
-      '@typescript-eslint/types': 5.36.0
-      '@typescript-eslint/typescript-estree': 5.36.0_typescript@4.8.2
+      '@typescript-eslint/scope-manager': 5.36.2
+      '@typescript-eslint/types': 5.36.2
+      '@typescript-eslint/typescript-estree': 5.36.2_typescript@4.8.3
       debug: 4.3.4
       eslint: 8.23.0
-      typescript: 4.8.2
+      typescript: 4.8.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/scope-manager/5.36.0:
-    resolution: {integrity: sha512-PZUC9sz0uCzRiuzbkh6BTec7FqgwXW03isumFVkuPw/Ug/6nbAqPUZaRy4w99WCOUuJTjhn3tMjsM94NtEj64g==}
+  /@typescript-eslint/scope-manager/5.36.2:
+    resolution: {integrity: sha512-cNNP51L8SkIFSfce8B1NSUBTJTu2Ts4nWeWbFrdaqjmn9yKrAaJUBHkyTZc0cL06OFHpb+JZq5AUHROS398Orw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      '@typescript-eslint/types': 5.36.0
-      '@typescript-eslint/visitor-keys': 5.36.0
+      '@typescript-eslint/types': 5.36.2
+      '@typescript-eslint/visitor-keys': 5.36.2
     dev: true
 
-  /@typescript-eslint/scope-manager/5.36.1:
-    resolution: {integrity: sha512-pGC2SH3/tXdu9IH3ItoqciD3f3RRGCh7hb9zPdN2Drsr341zgd6VbhP5OHQO/reUqihNltfPpMpTNihFMarP2w==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      '@typescript-eslint/types': 5.36.1
-      '@typescript-eslint/visitor-keys': 5.36.1
-    dev: true
-
-  /@typescript-eslint/type-utils/5.36.1_yqf6kl63nyoq5megxukfnom5rm:
-    resolution: {integrity: sha512-xfZhfmoQT6m3lmlqDvDzv9TiCYdw22cdj06xY0obSznBsT///GK5IEZQdGliXpAOaRL34o8phEvXzEo/VJx13Q==}
+  /@typescript-eslint/type-utils/5.36.2_itqs5654cmlnjraw6gjzqacppi:
+    resolution: {integrity: sha512-rPQtS5rfijUWLouhy6UmyNquKDPhQjKsaKH0WnY6hl/07lasj8gPaH2UD8xWkePn6SC+jW2i9c2DZVDnL+Dokw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: '*'
@@ -600,28 +583,23 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.36.1_typescript@4.8.2
-      '@typescript-eslint/utils': 5.36.1_yqf6kl63nyoq5megxukfnom5rm
+      '@typescript-eslint/typescript-estree': 5.36.2_typescript@4.8.3
+      '@typescript-eslint/utils': 5.36.2_itqs5654cmlnjraw6gjzqacppi
       debug: 4.3.4
       eslint: 8.23.0
-      tsutils: 3.21.0_typescript@4.8.2
-      typescript: 4.8.2
+      tsutils: 3.21.0_typescript@4.8.3
+      typescript: 4.8.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/types/5.36.0:
-    resolution: {integrity: sha512-3JJuLL1r3ljRpFdRPeOtgi14Vmpx+2JcR6gryeORmW3gPBY7R1jNYoq4yBN1L//ONZjMlbJ7SCIwugOStucYiQ==}
+  /@typescript-eslint/types/5.36.2:
+    resolution: {integrity: sha512-9OJSvvwuF1L5eS2EQgFUbECb99F0mwq501w0H0EkYULkhFa19Qq7WFbycdw1PexAc929asupbZcgjVIe6OK/XQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@typescript-eslint/types/5.36.1:
-    resolution: {integrity: sha512-jd93ShpsIk1KgBTx9E+hCSEuLCUFwi9V/urhjOWnOaksGZFbTOxAT47OH2d4NLJnLhkVD+wDbB48BuaycZPLBg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dev: true
-
-  /@typescript-eslint/typescript-estree/5.36.0_typescript@4.8.2:
-    resolution: {integrity: sha512-EW9wxi76delg/FS9+WV+fkPdwygYzRrzEucdqFVWXMQWPOjFy39mmNNEmxuO2jZHXzSQTXzhxiU1oH60AbIw9A==}
+  /@typescript-eslint/typescript-estree/5.36.2_typescript@4.8.3:
+    resolution: {integrity: sha512-8fyH+RfbKc0mTspfuEjlfqA4YywcwQK2Amcf6TDOwaRLg7Vwdu4bZzyvBZp4bjt1RRjQ5MDnOZahxMrt2l5v9w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       typescript: '*'
@@ -629,49 +607,28 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/types': 5.36.0
-      '@typescript-eslint/visitor-keys': 5.36.0
+      '@typescript-eslint/types': 5.36.2
+      '@typescript-eslint/visitor-keys': 5.36.2
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.7
-      tsutils: 3.21.0_typescript@4.8.2
-      typescript: 4.8.2
+      tsutils: 3.21.0_typescript@4.8.3
+      typescript: 4.8.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/typescript-estree/5.36.1_typescript@4.8.2:
-    resolution: {integrity: sha512-ih7V52zvHdiX6WcPjsOdmADhYMDN15SylWRZrT2OMy80wzKbc79n8wFW0xpWpU0x3VpBz/oDgTm2xwDAnFTl+g==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 5.36.1
-      '@typescript-eslint/visitor-keys': 5.36.1
-      debug: 4.3.4
-      globby: 11.1.0
-      is-glob: 4.0.3
-      semver: 7.3.7
-      tsutils: 3.21.0_typescript@4.8.2
-      typescript: 4.8.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@typescript-eslint/utils/5.36.1_yqf6kl63nyoq5megxukfnom5rm:
-    resolution: {integrity: sha512-lNj4FtTiXm5c+u0pUehozaUWhh7UYKnwryku0nxJlYUEWetyG92uw2pr+2Iy4M/u0ONMKzfrx7AsGBTCzORmIg==}
+  /@typescript-eslint/utils/5.36.2_itqs5654cmlnjraw6gjzqacppi:
+    resolution: {integrity: sha512-uNcopWonEITX96v9pefk9DC1bWMdkweeSsewJ6GeC7L6j2t0SJywisgkr9wUTtXk90fi2Eljj90HSHm3OGdGRg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@types/json-schema': 7.0.11
-      '@typescript-eslint/scope-manager': 5.36.1
-      '@typescript-eslint/types': 5.36.1
-      '@typescript-eslint/typescript-estree': 5.36.1_typescript@4.8.2
+      '@typescript-eslint/scope-manager': 5.36.2
+      '@typescript-eslint/types': 5.36.2
+      '@typescript-eslint/typescript-estree': 5.36.2_typescript@4.8.3
       eslint: 8.23.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@8.23.0
@@ -680,19 +637,11 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/visitor-keys/5.36.0:
-    resolution: {integrity: sha512-pdqSJwGKueOrpjYIex0T39xarDt1dn4p7XJ+6FqBWugNQwXlNGC5h62qayAIYZ/RPPtD+ButDWmpXT1eGtiaYg==}
+  /@typescript-eslint/visitor-keys/5.36.2:
+    resolution: {integrity: sha512-BtRvSR6dEdrNt7Net2/XDjbYKU5Ml6GqJgVfXT0CxTCJlnIqK7rAGreuWKMT2t8cFUT2Msv5oxw0GMRD7T5J7A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      '@typescript-eslint/types': 5.36.0
-      eslint-visitor-keys: 3.3.0
-    dev: true
-
-  /@typescript-eslint/visitor-keys/5.36.1:
-    resolution: {integrity: sha512-ojB9aRyRFzVMN3b5joSYni6FAS10BBSCAfKJhjJAV08t/a95aM6tAhz+O1jF+EtgxktuSO3wJysp2R+Def/IWQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      '@typescript-eslint/types': 5.36.1
+      '@typescript-eslint/types': 5.36.2
       eslint-visitor-keys: 3.3.0
     dev: true
 
@@ -848,11 +797,11 @@ packages:
       vue: 3.2.37
     dev: true
 
-  /@vitest/coverage-c8/0.22.1_@vitest+ui@0.22.1:
-    resolution: {integrity: sha512-KOOYpO7EGpaF+nD8GD+Y05D0JtZp12NUu6DdLXvBPqSOPo2HkZ7KNBtfR0rb6gOy3NLtGiWTYTzCwhajgb2HlA==}
+  /@vitest/coverage-c8/0.23.1_@vitest+ui@0.23.1:
+    resolution: {integrity: sha512-si3vK1h3BHdoGfb5J2jXstthROHwDW+yqVNGO/NOPG8642+d1RO/jFFvF3OSSYFEsxxcDL0uywEVcXCjGuPYdA==}
     dependencies:
       c8: 7.12.0
-      vitest: 0.22.1_@vitest+ui@0.22.1
+      vitest: 0.23.1_@vitest+ui@0.23.1
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/browser'
@@ -866,8 +815,8 @@ packages:
       - terser
     dev: true
 
-  /@vitest/ui/0.22.1:
-    resolution: {integrity: sha512-iiM2JN+vzY8pEejUbPPi0EgkEselI3RvrgMPNUOalxQRgtlNVGyMsM0Re99xQsrZ/eBkHgWrlW216gNDoeD5cA==}
+  /@vitest/ui/0.23.1:
+    resolution: {integrity: sha512-W1ygPK4aTyLTPsf6NX3gZFbH0X1ipNzlHhxTRnZ4/HpQXs/qKw5NDY45/U2yC66Fevj5kXHI1tdrNfN00NouFQ==}
     dependencies:
       sirv: 2.0.2
     dev: true
@@ -880,11 +829,11 @@ packages:
       estree-walker: 2.0.2
       source-map: 0.6.1
 
-  /@vue/compiler-core/3.2.38:
-    resolution: {integrity: sha512-/FsvnSu7Z+lkd/8KXMa4yYNUiqQrI22135gfsQYVGuh5tqEgOB0XqrUdb/KnCLa5+TmQLPwvyUnKMyCpu+SX3Q==}
+  /@vue/compiler-core/3.2.39:
+    resolution: {integrity: sha512-mf/36OWXqWn0wsC40nwRRGheR/qoID+lZXbIuLnr4/AngM0ov8Xvv8GHunC0rKRIkh60bTqydlqTeBo49rlbqw==}
     dependencies:
-      '@babel/parser': 7.18.13
-      '@vue/shared': 3.2.38
+      '@babel/parser': 7.19.0
+      '@vue/shared': 3.2.39
       estree-walker: 2.0.2
       source-map: 0.6.1
     dev: true
@@ -895,11 +844,11 @@ packages:
       '@vue/compiler-core': 3.2.37
       '@vue/shared': 3.2.37
 
-  /@vue/compiler-dom/3.2.38:
-    resolution: {integrity: sha512-zqX4FgUbw56kzHlgYuEEJR8mefFiiyR3u96498+zWPsLeh1WKvgIReoNE+U7gG8bCUdvsrJ0JRmev0Ky6n2O0g==}
+  /@vue/compiler-dom/3.2.39:
+    resolution: {integrity: sha512-HMFI25Be1C8vLEEv1hgEO1dWwG9QQ8LTTPmCkblVJY/O3OvWx6r1+zsox5mKPMGvqYEZa6l8j+xgOfUspgo7hw==}
     dependencies:
-      '@vue/compiler-core': 3.2.38
-      '@vue/shared': 3.2.38
+      '@vue/compiler-core': 3.2.39
+      '@vue/shared': 3.2.39
     dev: true
 
   /@vue/compiler-sfc/3.2.37:
@@ -916,15 +865,15 @@ packages:
       postcss: 8.4.14
       source-map: 0.6.1
 
-  /@vue/compiler-sfc/3.2.38:
-    resolution: {integrity: sha512-KZjrW32KloMYtTcHAFuw3CqsyWc5X6seb8KbkANSWt3Cz9p2qA8c1GJpSkksFP9ABb6an0FLCFl46ZFXx3kKpg==}
+  /@vue/compiler-sfc/3.2.39:
+    resolution: {integrity: sha512-fqAQgFs1/BxTUZkd0Vakn3teKUt//J3c420BgnYgEOoVdTwYpBTSXCMJ88GOBCylmUBbtquGPli9tVs7LzsWIA==}
     dependencies:
-      '@babel/parser': 7.18.13
-      '@vue/compiler-core': 3.2.38
-      '@vue/compiler-dom': 3.2.38
-      '@vue/compiler-ssr': 3.2.38
-      '@vue/reactivity-transform': 3.2.38
-      '@vue/shared': 3.2.38
+      '@babel/parser': 7.19.0
+      '@vue/compiler-core': 3.2.39
+      '@vue/compiler-dom': 3.2.39
+      '@vue/compiler-ssr': 3.2.39
+      '@vue/reactivity-transform': 3.2.39
+      '@vue/shared': 3.2.39
       estree-walker: 2.0.2
       magic-string: 0.25.9
       postcss: 8.4.16
@@ -937,11 +886,11 @@ packages:
       '@vue/compiler-dom': 3.2.37
       '@vue/shared': 3.2.37
 
-  /@vue/compiler-ssr/3.2.38:
-    resolution: {integrity: sha512-bm9jOeyv1H3UskNm4S6IfueKjUNFmi2kRweFIGnqaGkkRePjwEcfCVqyS3roe7HvF4ugsEkhf4+kIvDhip6XzQ==}
+  /@vue/compiler-ssr/3.2.39:
+    resolution: {integrity: sha512-EoGCJ6lincKOZGW+0Ky4WOKsSmqL7hp1ZYgen8M7u/mlvvEQUaO9tKKOy7K43M9U2aA3tPv0TuYYQFrEbK2eFQ==}
     dependencies:
-      '@vue/compiler-dom': 3.2.38
-      '@vue/shared': 3.2.38
+      '@vue/compiler-dom': 3.2.39
+      '@vue/shared': 3.2.39
     dev: true
 
   /@vue/reactivity-transform/3.2.37:
@@ -953,12 +902,12 @@ packages:
       estree-walker: 2.0.2
       magic-string: 0.25.9
 
-  /@vue/reactivity-transform/3.2.38:
-    resolution: {integrity: sha512-3SD3Jmi1yXrDwiNJqQ6fs1x61WsDLqVk4NyKVz78mkaIRh6d3IqtRnptgRfXn+Fzf+m6B1KxBYWq1APj6h4qeA==}
+  /@vue/reactivity-transform/3.2.39:
+    resolution: {integrity: sha512-HGuWu864zStiWs9wBC6JYOP1E00UjMdDWIG5W+FpUx28hV3uz9ODOKVNm/vdOy/Pvzg8+OcANxAVC85WFBbl3A==}
     dependencies:
-      '@babel/parser': 7.18.13
-      '@vue/compiler-core': 3.2.38
-      '@vue/shared': 3.2.38
+      '@babel/parser': 7.19.0
+      '@vue/compiler-core': 3.2.39
+      '@vue/shared': 3.2.39
       estree-walker: 2.0.2
       magic-string: 0.25.9
     dev: true
@@ -968,10 +917,10 @@ packages:
     dependencies:
       '@vue/shared': 3.2.37
 
-  /@vue/reactivity/3.2.38:
-    resolution: {integrity: sha512-6L4myYcH9HG2M25co7/BSo0skKFHpAN8PhkNPM4xRVkyGl1K5M3Jx4rp5bsYhvYze2K4+l+pioN4e6ZwFLUVtw==}
+  /@vue/reactivity/3.2.39:
+    resolution: {integrity: sha512-vlaYX2a3qMhIZfrw3Mtfd+BuU+TZmvDrPMa+6lpfzS9k/LnGxkSuf0fhkP0rMGfiOHPtyKoU9OJJJFGm92beVQ==}
     dependencies:
-      '@vue/shared': 3.2.38
+      '@vue/shared': 3.2.39
     dev: true
 
   /@vue/runtime-core/3.2.37:
@@ -980,11 +929,11 @@ packages:
       '@vue/reactivity': 3.2.37
       '@vue/shared': 3.2.37
 
-  /@vue/runtime-core/3.2.38:
-    resolution: {integrity: sha512-kk0qiSiXUU/IKxZw31824rxmFzrLr3TL6ZcbrxWTKivadoKupdlzbQM4SlGo4MU6Zzrqv4fzyUasTU1jDoEnzg==}
+  /@vue/runtime-core/3.2.39:
+    resolution: {integrity: sha512-xKH5XP57JW5JW+8ZG1khBbuLakINTgPuINKL01hStWLTTGFOrM49UfCFXBcFvWmSbci3gmJyLl2EAzCaZWsx8g==}
     dependencies:
-      '@vue/reactivity': 3.2.38
-      '@vue/shared': 3.2.38
+      '@vue/reactivity': 3.2.39
+      '@vue/shared': 3.2.39
     dev: true
 
   /@vue/runtime-dom/3.2.37:
@@ -994,11 +943,11 @@ packages:
       '@vue/shared': 3.2.37
       csstype: 2.6.20
 
-  /@vue/runtime-dom/3.2.38:
-    resolution: {integrity: sha512-4PKAb/ck2TjxdMSzMsnHViOrrwpudk4/A56uZjhzvusoEU9xqa5dygksbzYepdZeB5NqtRw5fRhWIiQlRVK45A==}
+  /@vue/runtime-dom/3.2.39:
+    resolution: {integrity: sha512-4G9AEJP+sLhsqf5wXcyKVWQKUhI+iWfy0hWQgea+CpaTD7BR0KdQzvoQdZhwCY6B3oleSyNLkLAQwm0ya/wNoA==}
     dependencies:
-      '@vue/runtime-core': 3.2.38
-      '@vue/shared': 3.2.38
+      '@vue/runtime-core': 3.2.39
+      '@vue/shared': 3.2.39
       csstype: 2.6.20
     dev: true
 
@@ -1011,21 +960,21 @@ packages:
       '@vue/shared': 3.2.37
       vue: 3.2.37
 
-  /@vue/server-renderer/3.2.38_vue@3.2.38:
-    resolution: {integrity: sha512-pg+JanpbOZ5kEfOZzO2bt02YHd+ELhYP8zPeLU1H0e7lg079NtuuSB8fjLdn58c4Ou8UQ6C1/P+528nXnLPAhA==}
+  /@vue/server-renderer/3.2.39_vue@3.2.39:
+    resolution: {integrity: sha512-1yn9u2YBQWIgytFMjz4f/t0j43awKytTGVptfd3FtBk76t1pd8mxbek0G/DrnjJhd2V7mSTb5qgnxMYt8Z5iSQ==}
     peerDependencies:
-      vue: 3.2.38
+      vue: 3.2.39
     dependencies:
-      '@vue/compiler-ssr': 3.2.38
-      '@vue/shared': 3.2.38
-      vue: 3.2.38
+      '@vue/compiler-ssr': 3.2.39
+      '@vue/shared': 3.2.39
+      vue: 3.2.39
     dev: true
 
   /@vue/shared/3.2.37:
     resolution: {integrity: sha512-4rSJemR2NQIo9Klm1vabqWjD8rs/ZaJSzMxkMNeJS6lHiUjjUeYFbooN19NgFjztubEKh3WlZUeOLVdbbUWHsw==}
 
-  /@vue/shared/3.2.38:
-    resolution: {integrity: sha512-dTyhTIRmGXBjxJE+skC8tTWCGLCVc4wQgRRLt8+O9p5ewBAjoBwtCAkLPrtToSr1xltoe3st21Pv953aOZ7alg==}
+  /@vue/shared/3.2.39:
+    resolution: {integrity: sha512-D3dl2ZB9qE6mTuWPk9RlhDeP1dgNRUKC3NJxji74A4yL8M2MwlhLKUC/49WHjrNzSPug58fWx/yFbaTzGAQSBw==}
     dev: true
 
   /@vueuse/core/9.1.0_vue@3.2.37:
@@ -1114,7 +1063,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.4
-      es-abstract: 1.20.1
+      es-abstract: 1.20.2
       get-intrinsic: 1.1.2
       is-string: 1.0.7
     dev: true
@@ -1130,7 +1079,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.4
-      es-abstract: 1.20.1
+      es-abstract: 1.20.2
       es-shim-unscopables: 1.0.0
     dev: true
 
@@ -1140,7 +1089,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.4
-      es-abstract: 1.20.1
+      es-abstract: 1.20.2
       es-shim-unscopables: 1.0.0
     dev: true
 
@@ -1202,19 +1151,19 @@ packages:
     dependencies:
       '@jsdevtools/ez-spawn': 3.0.4
       cac: 6.7.14
-      fast-glob: 3.2.11
+      fast-glob: 3.2.12
       kleur: 4.1.5
       prompts: 2.4.2
       semver: 7.3.7
     dev: true
 
-  /bundle-require/3.1.0_esbuild@0.15.6:
+  /bundle-require/3.1.0_esbuild@0.15.7:
     resolution: {integrity: sha512-IIXtAO7fKcwPHNPt9kY/WNVJqy7NDy6YqJvv6ENH0TOZoJ+yjpEsn1w40WKZbR2ibfu5g1rfgJTvmFHpm5aOMA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     peerDependencies:
       esbuild: '>=0.13'
     dependencies:
-      esbuild: 0.15.6
+      esbuild: 0.15.7
       load-tsconfig: 0.2.3
     dev: true
 
@@ -1507,7 +1456,7 @@ packages:
     dependencies:
       domelementtype: 2.3.0
       domhandler: 5.0.3
-      entities: 4.3.1
+      entities: 4.4.0
     dev: true
 
   /domelementtype/2.3.0:
@@ -1537,8 +1486,8 @@ packages:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
     dev: true
 
-  /entities/4.3.1:
-    resolution: {integrity: sha512-o4q/dYJlmyjP2zfnaWDUC6A3BQFmVTX+tZPezK7k0GLSU9QYCauscf5Y+qcEPzKL+EixVouYDgLQK5H9GrLpkg==}
+  /entities/4.4.0:
+    resolution: {integrity: sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==}
     engines: {node: '>=0.12'}
     dev: true
 
@@ -1548,8 +1497,8 @@ packages:
       is-arrayish: 0.2.1
     dev: true
 
-  /es-abstract/1.20.1:
-    resolution: {integrity: sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==}
+  /es-abstract/1.20.2:
+    resolution: {integrity: sha512-XxXQuVNrySBNlEkTYJoDNFe5+s2yIOpzq80sUHEdPdQr0S5nTLz4ZPPPswNIpKseDDUS5yghX1gfLIHQZ1iNuQ==}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
@@ -1601,17 +1550,8 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-android-64/0.14.54:
-    resolution: {integrity: sha512-Tz2++Aqqz0rJ7kYBfz+iqyE3QMycD4vk7LBRyWaAVFgFtQ/O8EJOnVmTOiDWYZ/uYzB4kvP+bqejYdVKzE5lAQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-android-64/0.15.6:
-    resolution: {integrity: sha512-Z1CHSgB1crVQi2LKSBwSkpaGtaloVz0ZIYcRMsvHc3uSXcR/x5/bv9wcZspvH/25lIGTaViosciS/NS09ERmVA==}
+  /esbuild-android-64/0.15.7:
+    resolution: {integrity: sha512-p7rCvdsldhxQr3YHxptf1Jcd86dlhvc3EQmQJaZzzuAxefO9PvcI0GLOa5nCWem1AJ8iMRu9w0r5TG8pHmbi9w==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
@@ -1628,17 +1568,8 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-android-arm64/0.14.54:
-    resolution: {integrity: sha512-F9E+/QDi9sSkLaClO8SOV6etqPd+5DgJje1F9lOWoNncDdOBL2YF59IhsWATSt0TLZbYCf3pNlTHvVV5VfHdvg==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-android-arm64/0.15.6:
-    resolution: {integrity: sha512-mvM+gqNxqKm2pCa3dnjdRzl7gIowuc4ga7P7c3yHzs58Im8v/Lfk1ixSgQ2USgIywT48QWaACRa3F4MG7djpSw==}
+  /esbuild-android-arm64/0.15.7:
+    resolution: {integrity: sha512-L775l9ynJT7rVqRM5vo+9w5g2ysbOCfsdLV4CWanTZ1k/9Jb3IYlQ06VCI1edhcosTYJRECQFJa3eAvkx72eyQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -1655,17 +1586,8 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-darwin-64/0.14.54:
-    resolution: {integrity: sha512-jtdKWV3nBviOd5v4hOpkVmpxsBy90CGzebpbO9beiqUYVMBtSc0AL9zGftFuBon7PNDcdvNCEuQqw2x0wP9yug==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-darwin-64/0.15.6:
-    resolution: {integrity: sha512-BsfVt3usScAfGlXJiGtGamwVEOTM8AiYiw1zqDWhGv6BncLXCnTg1As+90mxWewdTZKq3iIy8s9g8CKkrrAXVw==}
+  /esbuild-darwin-64/0.15.7:
+    resolution: {integrity: sha512-KGPt3r1c9ww009t2xLB6Vk0YyNOXh7hbjZ3EecHoVDxgtbUlYstMPDaReimKe6eOEfyY4hBEEeTvKwPsiH5WZg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
@@ -1682,17 +1604,8 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-darwin-arm64/0.14.54:
-    resolution: {integrity: sha512-OPafJHD2oUPyvJMrsCvDGkRrVCar5aVyHfWGQzY1dWnzErjrDuSETxwA2HSsyg2jORLY8yBfzc1MIpUkXlctmw==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-darwin-arm64/0.15.6:
-    resolution: {integrity: sha512-CnrAeJaEpPakUobhqO4wVSA4Zm6TPaI5UY4EsI62j9mTrjIyQPXA1n4Ju6Iu5TVZRnEqV6q8blodgYJ6CJuwCA==}
+  /esbuild-darwin-arm64/0.15.7:
+    resolution: {integrity: sha512-kBIHvtVqbSGajN88lYMnR3aIleH3ABZLLFLxwL2stiuIGAjGlQW741NxVTpUHQXUmPzxi6POqc9npkXa8AcSZQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
@@ -1709,17 +1622,8 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-freebsd-64/0.14.54:
-    resolution: {integrity: sha512-OKwd4gmwHqOTp4mOGZKe/XUlbDJ4Q9TjX0hMPIDBUWWu/kwhBAudJdBoxnjNf9ocIB6GN6CPowYpR/hRCbSYAg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-freebsd-64/0.15.6:
-    resolution: {integrity: sha512-+qFdmqi+jkAsxsNJkaWVrnxEUUI50nu6c3MBVarv3RCDCbz7ZS1a4ZrdkwEYFnKcVWu6UUE0Kkb1SQ1yGEG6sg==}
+  /esbuild-freebsd-64/0.15.7:
+    resolution: {integrity: sha512-hESZB91qDLV5MEwNxzMxPfbjAhOmtfsr9Wnuci7pY6TtEh4UDuevmGmkUIjX/b+e/k4tcNBMf7SRQ2mdNuK/HQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
@@ -1736,17 +1640,8 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-freebsd-arm64/0.14.54:
-    resolution: {integrity: sha512-sFwueGr7OvIFiQT6WeG0jRLjkjdqWWSrfbVwZp8iMP+8UHEHRBvlaxL6IuKNDwAozNUmbb8nIMXa7oAOARGs1Q==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-freebsd-arm64/0.15.6:
-    resolution: {integrity: sha512-KtQkQOhnNciXm2yrTYZMD3MOm2zBiiwFSU+dkwNbcfDumzzUprr1x70ClTdGuZwieBS1BM/k0KajRQX7r504Xw==}
+  /esbuild-freebsd-arm64/0.15.7:
+    resolution: {integrity: sha512-dLFR0ChH5t+b3J8w0fVKGvtwSLWCv7GYT2Y2jFGulF1L5HftQLzVGN+6pi1SivuiVSmTh28FwUhi9PwQicXI6Q==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
@@ -1763,17 +1658,8 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-linux-32/0.14.54:
-    resolution: {integrity: sha512-1ZuY+JDI//WmklKlBgJnglpUL1owm2OX+8E1syCD6UAxcMM/XoWd76OHSjl/0MR0LisSAXDqgjT3uJqT67O3qw==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-32/0.15.6:
-    resolution: {integrity: sha512-IAkDNz3TpxwISTGVdQijwyHBZrbFgLlRi5YXcvaEHtgbmayLSDcJmH5nV1MFgo/x2QdKcHBkOYHdjhKxUAcPwg==}
+  /esbuild-linux-32/0.15.7:
+    resolution: {integrity: sha512-v3gT/LsONGUZcjbt2swrMjwxo32NJzk+7sAgtxhGx1+ZmOFaTRXBAi1PPfgpeo/J//Un2jIKm/I+qqeo4caJvg==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
@@ -1790,17 +1676,8 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-linux-64/0.14.54:
-    resolution: {integrity: sha512-EgjAgH5HwTbtNsTqQOXWApBaPVdDn7XcK+/PtJwZLT1UmpLoznPd8c5CxqsH2dQK3j05YsB3L17T8vE7cp4cCg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-64/0.15.6:
-    resolution: {integrity: sha512-gQPksyrEYfA4LJwyfTQWAZaVZCx4wpaLrSzo2+Xc9QLC+i/sMWmX31jBjrn4nLJCd79KvwCinto36QC7BEIU/A==}
+  /esbuild-linux-64/0.15.7:
+    resolution: {integrity: sha512-LxXEfLAKwOVmm1yecpMmWERBshl+Kv5YJ/1KnyAr6HRHFW8cxOEsEfisD3sVl/RvHyW//lhYUVSuy9jGEfIRAQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
@@ -1817,17 +1694,8 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-linux-arm/0.14.54:
-    resolution: {integrity: sha512-qqz/SjemQhVMTnvcLGoLOdFpCYbz4v4fUo+TfsWG+1aOu70/80RV6bgNpR2JCrppV2moUQkww+6bWxXRL9YMGw==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-arm/0.15.6:
-    resolution: {integrity: sha512-xZ0Bq2aivsthDjA/ytQZzxrxIZbG0ATJYMJxNeOIBc1zUjpbVpzBKgllOZMsTSXMHFHGrow6TnCcgwqY0+oEoQ==}
+  /esbuild-linux-arm/0.15.7:
+    resolution: {integrity: sha512-JKgAHtMR5f75wJTeuNQbyznZZa+pjiUHV7sRZp42UNdyXC6TiUYMW/8z8yIBAr2Fpad8hM1royZKQisqPABPvQ==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
@@ -1844,17 +1712,8 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-linux-arm64/0.14.54:
-    resolution: {integrity: sha512-WL71L+0Rwv+Gv/HTmxTEmpv0UgmxYa5ftZILVi2QmZBgX3q7+tDeOQNqGtdXSdsL8TQi1vIaVFHUPDe0O0kdig==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-arm64/0.15.6:
-    resolution: {integrity: sha512-aovDkclFa6C9EdZVBuOXxqZx83fuoq8097xZKhEPSygwuy4Lxs8J4anHG7kojAsR+31lfUuxzOo2tHxv7EiNHA==}
+  /esbuild-linux-arm64/0.15.7:
+    resolution: {integrity: sha512-P3cfhudpzWDkglutWgXcT2S7Ft7o2e3YDMrP1n0z2dlbUZghUkKCyaWw0zhp4KxEEzt/E7lmrtRu/pGWnwb9vw==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
@@ -1871,17 +1730,8 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-linux-mips64le/0.14.54:
-    resolution: {integrity: sha512-qTHGQB8D1etd0u1+sB6p0ikLKRVuCWhYQhAHRPkO+OF3I/iSlTKNNS0Lh2Oc0g0UFGguaFZZiPJdJey3AGpAlw==}
-    engines: {node: '>=12'}
-    cpu: [mips64el]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-mips64le/0.15.6:
-    resolution: {integrity: sha512-wVpW8wkWOGizsCqCwOR/G3SHwhaecpGy3fic9BF1r7vq4djLjUcA8KunDaBCjJ6TgLQFhJ98RjDuyEf8AGjAvw==}
+  /esbuild-linux-mips64le/0.15.7:
+    resolution: {integrity: sha512-T7XKuxl0VpeFLCJXub6U+iybiqh0kM/bWOTb4qcPyDDwNVhLUiPcGdG2/0S7F93czUZOKP57YiLV8YQewgLHKw==}
     engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
@@ -1898,17 +1748,8 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-linux-ppc64le/0.14.54:
-    resolution: {integrity: sha512-j3OMlzHiqwZBDPRCDFKcx595XVfOfOnv68Ax3U4UKZ3MTYQB5Yz3X1mn5GnodEVYzhtZgxEBidLWeIs8FDSfrQ==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-ppc64le/0.15.6:
-    resolution: {integrity: sha512-z6w6gsPH/Y77uchocluDC8tkCg9rfkcPTePzZKNr879bF4tu7j9t255wuNOCE396IYEGxY7y8u2HJ9i7kjCLVw==}
+  /esbuild-linux-ppc64le/0.15.7:
+    resolution: {integrity: sha512-6mGuC19WpFN7NYbecMIJjeQgvDb5aMuvyk0PDYBJrqAEMkTwg3Z98kEKuCm6THHRnrgsdr7bp4SruSAxEM4eJw==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
@@ -1925,17 +1766,8 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-linux-riscv64/0.14.54:
-    resolution: {integrity: sha512-y7Vt7Wl9dkOGZjxQZnDAqqn+XOqFD7IMWiewY5SPlNlzMX39ocPQlOaoxvT4FllA5viyV26/QzHtvTjVNOxHZg==}
-    engines: {node: '>=12'}
-    cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-riscv64/0.15.6:
-    resolution: {integrity: sha512-pfK/3MJcmbfU399TnXW5RTPS1S+ID6ra+CVj9TFZ2s0q9Ja1F5A1VirUUvViPkjiw+Kq3zveyn6U09Wg1zJXrw==}
+  /esbuild-linux-riscv64/0.15.7:
+    resolution: {integrity: sha512-uUJsezbswAYo/X7OU/P+PuL/EI9WzxsEQXDekfwpQ23uGiooxqoLFAPmXPcRAt941vjlY9jtITEEikWMBr+F/g==}
     engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
@@ -1952,17 +1784,8 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-linux-s390x/0.14.54:
-    resolution: {integrity: sha512-zaHpW9dziAsi7lRcyV4r8dhfG1qBidQWUXweUjnw+lliChJqQr+6XD71K41oEIC3Mx1KStovEmlzm+MkGZHnHA==}
-    engines: {node: '>=12'}
-    cpu: [s390x]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-s390x/0.15.6:
-    resolution: {integrity: sha512-OZeeDu32liefcwAE63FhVqM4heWTC8E3MglOC7SK0KYocDdY/6jyApw0UDkDHlcEK9mW6alX/SH9r3PDjcCo/Q==}
+  /esbuild-linux-s390x/0.15.7:
+    resolution: {integrity: sha512-+tO+xOyTNMc34rXlSxK7aCwJgvQyffqEM5MMdNDEeMU3ss0S6wKvbBOQfgd5jRPblfwJ6b+bKiz0g5nABpY0QQ==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
@@ -1979,17 +1802,8 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-netbsd-64/0.14.54:
-    resolution: {integrity: sha512-PR01lmIMnfJTgeU9VJTDY9ZerDWVFIUzAtJuDHwwceppW7cQWjBBqP48NdeRtoP04/AtO9a7w3viI+PIDr6d+w==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [netbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-netbsd-64/0.15.6:
-    resolution: {integrity: sha512-kaxw61wcHMyiEsSsi5ut1YYs/hvTC2QkxJwyRvC2Cnsz3lfMLEu8zAjpBKWh9aU/N0O/gsRap4wTur5GRuSvBA==}
+  /esbuild-netbsd-64/0.15.7:
+    resolution: {integrity: sha512-yVc4Wz+Pu3cP5hzm5kIygNPrjar/v5WCSoRmIjCPWfBVJkZNb5brEGKUlf+0Y759D48BCWa0WHrWXaNy0DULTQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
@@ -2006,17 +1820,8 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-openbsd-64/0.14.54:
-    resolution: {integrity: sha512-Qyk7ikT2o7Wu76UsvvDS5q0amJvmRzDyVlL0qf5VLsLchjCa1+IAvd8kTBgUxD7VBUUVgItLkk609ZHUc1oCaw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [openbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-openbsd-64/0.15.6:
-    resolution: {integrity: sha512-CuoY60alzYfIZapUHqFXqXbj88bbRJu8Fp9okCSHRX2zWIcGz4BXAHXiG7dlCye5nFVrY72psesLuWdusyf2qw==}
+  /esbuild-openbsd-64/0.15.7:
+    resolution: {integrity: sha512-GsimbwC4FSR4lN3wf8XmTQ+r8/0YSQo21rWDL0XFFhLHKlzEA4SsT1Tl8bPYu00IU6UWSJ+b3fG/8SB69rcuEQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
@@ -2033,17 +1838,8 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-sunos-64/0.14.54:
-    resolution: {integrity: sha512-28GZ24KmMSeKi5ueWzMcco6EBHStL3B6ubM7M51RmPwXQGLe0teBGJocmWhgwccA1GeFXqxzILIxXpHbl9Q/Kw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [sunos]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-sunos-64/0.15.6:
-    resolution: {integrity: sha512-1ceefLdPWcd1nW/ZLruPEYxeUEAVX0YHbG7w+BB4aYgfknaLGotI/ZvPWUZpzhC8l1EybrVlz++lm3E6ODIJOg==}
+  /esbuild-sunos-64/0.15.7:
+    resolution: {integrity: sha512-8CDI1aL/ts0mDGbWzjEOGKXnU7p3rDzggHSBtVryQzkSOsjCHRVe0iFYUuhczlxU1R3LN/E7HgUO4NXzGGP/Ag==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
@@ -2060,17 +1856,8 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-windows-32/0.14.54:
-    resolution: {integrity: sha512-T+rdZW19ql9MjS7pixmZYVObd9G7kcaZo+sETqNH4RCkuuYSuv9AGHUVnPoP9hhuE1WM1ZimHz1CIBHBboLU7w==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-windows-32/0.15.6:
-    resolution: {integrity: sha512-pBqdOsKqCD5LRYiwF29PJRDJZi7/Wgkz46u3d17MRFmrLFcAZDke3nbdDa1c8YgY78RiemudfCeAemN8EBlIpA==}
+  /esbuild-windows-32/0.15.7:
+    resolution: {integrity: sha512-cOnKXUEPS8EGCzRSFa1x6NQjGhGsFlVgjhqGEbLTPsA7x4RRYiy2RKoArNUU4iR2vHmzqS5Gr84MEumO/wxYKA==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
@@ -2087,17 +1874,8 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-windows-64/0.14.54:
-    resolution: {integrity: sha512-AoHTRBUuYwXtZhjXZbA1pGfTo8cJo3vZIcWGLiUcTNgHpJJMC1rVA44ZereBHMJtotyN71S8Qw0npiCIkW96cQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-windows-64/0.15.6:
-    resolution: {integrity: sha512-KpPOh4aTOo//g9Pk2oVAzXMpc9Sz9n5A9sZTmWqDSXCiiachfFhbuFlsKBGATYCVitXfmBIJ4nNYYWSOdz4hQg==}
+  /esbuild-windows-64/0.15.7:
+    resolution: {integrity: sha512-7MI08Ec2sTIDv+zH6StNBKO+2hGUYIT42GmFyW6MBBWWtJhTcQLinKS6ldIN1d52MXIbiJ6nXyCJ+LpL4jBm3Q==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
@@ -2114,17 +1892,8 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-windows-arm64/0.14.54:
-    resolution: {integrity: sha512-M0kuUvXhot1zOISQGXwWn6YtS+Y/1RT9WrVIOywZnJHo3jCDyewAc79aKNQWFCQm+xNHVTq9h8dZKvygoXQQRg==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-windows-arm64/0.15.6:
-    resolution: {integrity: sha512-DB3G2x9OvFEa00jV+OkDBYpufq5x/K7a6VW6E2iM896DG4ZnAvJKQksOsCPiM1DUaa+DrijXAQ/ZOcKAqf/3Hg==}
+  /esbuild-windows-arm64/0.15.7:
+    resolution: {integrity: sha512-R06nmqBlWjKHddhRJYlqDd3Fabx9LFdKcjoOy08YLimwmsswlFBJV4rXzZCxz/b7ZJXvrZgj8DDv1ewE9+StMw==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
@@ -2161,62 +1930,33 @@ packages:
       esbuild-windows-arm64: 0.14.53
     dev: true
 
-  /esbuild/0.14.54:
-    resolution: {integrity: sha512-Cy9llcy8DvET5uznocPyqL3BFRrFXSVqbgpMJ9Wz8oVjZlh/zUSNbPRbov0VX7VxN2JH1Oa0uNxZ7eLRb62pJA==}
+  /esbuild/0.15.7:
+    resolution: {integrity: sha512-7V8tzllIbAQV1M4QoE52ImKu8hT/NLGlGXkiDsbEU5PS6K8Mn09ZnYoS+dcmHxOS9CRsV4IRAMdT3I67IyUNXw==}
     engines: {node: '>=12'}
     hasBin: true
     requiresBuild: true
     optionalDependencies:
-      '@esbuild/linux-loong64': 0.14.54
-      esbuild-android-64: 0.14.54
-      esbuild-android-arm64: 0.14.54
-      esbuild-darwin-64: 0.14.54
-      esbuild-darwin-arm64: 0.14.54
-      esbuild-freebsd-64: 0.14.54
-      esbuild-freebsd-arm64: 0.14.54
-      esbuild-linux-32: 0.14.54
-      esbuild-linux-64: 0.14.54
-      esbuild-linux-arm: 0.14.54
-      esbuild-linux-arm64: 0.14.54
-      esbuild-linux-mips64le: 0.14.54
-      esbuild-linux-ppc64le: 0.14.54
-      esbuild-linux-riscv64: 0.14.54
-      esbuild-linux-s390x: 0.14.54
-      esbuild-netbsd-64: 0.14.54
-      esbuild-openbsd-64: 0.14.54
-      esbuild-sunos-64: 0.14.54
-      esbuild-windows-32: 0.14.54
-      esbuild-windows-64: 0.14.54
-      esbuild-windows-arm64: 0.14.54
-    dev: true
-
-  /esbuild/0.15.6:
-    resolution: {integrity: sha512-sgLOv3l4xklvXzzczhRwKRotyrfyZ2i1fCS6PTOLPd9wevDPArGU8HFtHrHCOcsMwTjLjzGm15gvC8uxVzQf+w==}
-    engines: {node: '>=12'}
-    hasBin: true
-    requiresBuild: true
-    optionalDependencies:
-      '@esbuild/linux-loong64': 0.15.6
-      esbuild-android-64: 0.15.6
-      esbuild-android-arm64: 0.15.6
-      esbuild-darwin-64: 0.15.6
-      esbuild-darwin-arm64: 0.15.6
-      esbuild-freebsd-64: 0.15.6
-      esbuild-freebsd-arm64: 0.15.6
-      esbuild-linux-32: 0.15.6
-      esbuild-linux-64: 0.15.6
-      esbuild-linux-arm: 0.15.6
-      esbuild-linux-arm64: 0.15.6
-      esbuild-linux-mips64le: 0.15.6
-      esbuild-linux-ppc64le: 0.15.6
-      esbuild-linux-riscv64: 0.15.6
-      esbuild-linux-s390x: 0.15.6
-      esbuild-netbsd-64: 0.15.6
-      esbuild-openbsd-64: 0.15.6
-      esbuild-sunos-64: 0.15.6
-      esbuild-windows-32: 0.15.6
-      esbuild-windows-64: 0.15.6
-      esbuild-windows-arm64: 0.15.6
+      '@esbuild/linux-loong64': 0.15.7
+      esbuild-android-64: 0.15.7
+      esbuild-android-arm64: 0.15.7
+      esbuild-darwin-64: 0.15.7
+      esbuild-darwin-arm64: 0.15.7
+      esbuild-freebsd-64: 0.15.7
+      esbuild-freebsd-arm64: 0.15.7
+      esbuild-linux-32: 0.15.7
+      esbuild-linux-64: 0.15.7
+      esbuild-linux-arm: 0.15.7
+      esbuild-linux-arm64: 0.15.7
+      esbuild-linux-mips64le: 0.15.7
+      esbuild-linux-ppc64le: 0.15.7
+      esbuild-linux-riscv64: 0.15.7
+      esbuild-linux-s390x: 0.15.7
+      esbuild-netbsd-64: 0.15.7
+      esbuild-openbsd-64: 0.15.7
+      esbuild-sunos-64: 0.15.7
+      esbuild-windows-32: 0.15.7
+      esbuild-windows-64: 0.15.7
+      esbuild-windows-arm64: 0.15.7
     dev: true
 
   /escalade/3.1.1:
@@ -2248,7 +1988,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils/2.7.4_xkxb4lzhcyntw6mmn4s5kvlnz4:
+  /eslint-module-utils/2.7.4_jkckkukndwd4xurous7ym67tze:
     resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -2269,7 +2009,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.36.0_yqf6kl63nyoq5megxukfnom5rm
+      '@typescript-eslint/parser': 5.36.2_itqs5654cmlnjraw6gjzqacppi
       debug: 3.2.7
       eslint: 8.23.0
       eslint-import-resolver-node: 0.3.6
@@ -2277,10 +2017,10 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-antfu/0.26.2_yqf6kl63nyoq5megxukfnom5rm:
-    resolution: {integrity: sha512-WlrMC8DVTehsb6ha3xnALLtWVVSJvIpzdAgS0ZEUS9wQzsU+VoR71aShzbUZPgSK3iiB+mP8aKHDtwcYnV6wsA==}
+  /eslint-plugin-antfu/0.26.3_itqs5654cmlnjraw6gjzqacppi:
+    resolution: {integrity: sha512-w64+iWWMSrlsX0oNTuAE0XcgPl3kP2L6xU0iKdLuSTOmhULPE4BoUNuYpD0XUKbP2Ke4JxB+DP/uBNb7jykfbg==}
     dependencies:
-      '@typescript-eslint/utils': 5.36.1_yqf6kl63nyoq5megxukfnom5rm
+      '@typescript-eslint/utils': 5.36.2_itqs5654cmlnjraw6gjzqacppi
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -2315,7 +2055,7 @@ packages:
       htmlparser2: 8.0.1
     dev: true
 
-  /eslint-plugin-import/2.26.0_en2wbs6aggmxy4drejzsyh4gce:
+  /eslint-plugin-import/2.26.0_iepzrjnvahcxaf6zc7cutko6om:
     resolution: {integrity: sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -2325,14 +2065,14 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.36.0_yqf6kl63nyoq5megxukfnom5rm
+      '@typescript-eslint/parser': 5.36.2_itqs5654cmlnjraw6gjzqacppi
       array-includes: 3.1.5
       array.prototype.flat: 1.3.0
       debug: 2.6.9
       doctrine: 2.1.0
       eslint: 8.23.0
       eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.4_xkxb4lzhcyntw6mmn4s5kvlnz4
+      eslint-module-utils: 2.7.4_jkckkukndwd4xurous7ym67tze
       has: 1.0.3
       is-core-module: 2.10.0
       is-glob: 4.0.3
@@ -2396,8 +2136,8 @@ packages:
       eslint: 8.23.0
     dev: true
 
-  /eslint-plugin-react/7.31.1_eslint@8.23.0:
-    resolution: {integrity: sha512-j4/2xWqt/R7AZzG8CakGHA6Xa/u7iR8Q3xCxY+AUghdT92bnIDOBEefV456OeH0QvBcroVc0eyvrrLSyQGYIfg==}
+  /eslint-plugin-react/7.31.8_eslint@8.23.0:
+    resolution: {integrity: sha512-5lBTZmgQmARLLSYiwI71tiGVTLUuqXantZM6vlSY39OaDSV0M7+32K5DnLkmFrwTe+Ksz0ffuLUC91RUviVZfw==}
     engines: {node: '>=4'}
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
@@ -2454,14 +2194,14 @@ packages:
       nth-check: 2.1.1
       postcss-selector-parser: 6.0.10
       semver: 7.3.7
-      vue-eslint-parser: 9.0.3_eslint@8.23.0
+      vue-eslint-parser: 9.1.0_eslint@8.23.0
       xml-name-validator: 4.0.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /eslint-plugin-yml/1.1.0_eslint@8.23.0:
-    resolution: {integrity: sha512-64g3vWwolk9d+FykuqxXGLn3oGEK2ZecIAyfIEsyuSHBQkR8utp5h8e75R6tGph1IRggoGl27QQ2oi2M1IF1Vw==}
+  /eslint-plugin-yml/1.2.0_eslint@8.23.0:
+    resolution: {integrity: sha512-v0jAU/F5SJg28zkpxwGpY04eGZMWFP6os8u2qaEAIRjSH2GqrNl0yBR5+sMHLU/026kAduxVbvLSqmT3Mu3O0g==}
     engines: {node: ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: '>=6.0.0'
@@ -2647,6 +2387,17 @@ packages:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.5
+    dev: true
+
+  /fast-glob/3.2.12:
+    resolution: {integrity: sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==}
+    engines: {node: '>=8.6.0'}
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.5
 
   /fast-json-stable-stringify/2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
@@ -2732,7 +2483,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.4
-      es-abstract: 1.20.1
+      es-abstract: 1.20.2
       functions-have-names: 1.2.3
     dev: true
 
@@ -2838,7 +2589,7 @@ packages:
     dependencies:
       array-union: 2.1.0
       dir-glob: 3.0.1
-      fast-glob: 3.2.11
+      fast-glob: 3.2.12
       ignore: 5.2.0
       merge2: 1.4.1
       slash: 3.0.0
@@ -2908,7 +2659,7 @@ packages:
       domelementtype: 2.3.0
       domhandler: 5.0.3
       domutils: 3.0.1
-      entities: 4.3.1
+      entities: 4.4.0
     dev: true
 
   /human-signals/2.1.0:
@@ -3464,7 +3215,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.4
-      es-abstract: 1.20.1
+      es-abstract: 1.20.2
     dev: true
 
   /object.fromentries/2.0.5:
@@ -3473,14 +3224,14 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.4
-      es-abstract: 1.20.1
+      es-abstract: 1.20.2
     dev: true
 
   /object.hasown/1.1.1:
     resolution: {integrity: sha512-LYLe4tivNQzq4JdaWW6WO3HMZZJWzkkH8fnI6EebWl0VZth2wL2Lovm74ep2/gZzlaTdV62JZHEqHQ2yVn8Q/A==}
     dependencies:
       define-properties: 1.1.4
-      es-abstract: 1.20.1
+      es-abstract: 1.20.2
     dev: true
 
   /object.values/1.1.5:
@@ -3489,7 +3240,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.4
-      es-abstract: 1.20.1
+      es-abstract: 1.20.2
     dev: true
 
   /ohmyfetch/0.4.18:
@@ -3819,16 +3570,16 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /rollup/2.77.3:
-    resolution: {integrity: sha512-/qxNTG7FbmefJWoeeYJFbHehJ2HNWnjkAFRKzWN/45eNBBF/r8lo992CwcJXEzyVxs5FmfId+vTSTQDb+bxA+g==}
+  /rollup/2.78.1:
+    resolution: {integrity: sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==}
     engines: {node: '>=10.0.0'}
     hasBin: true
     optionalDependencies:
       fsevents: 2.3.2
     dev: true
 
-  /rollup/2.78.1:
-    resolution: {integrity: sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==}
+  /rollup/2.79.0:
+    resolution: {integrity: sha512-x4KsrCgwQ7ZJPcFA/SUu6QVcYlO7uRLfLAy0DSA4NS2eG8japdbpM50ToH7z4iObodRYOJ0soneF0iaQRJ6zhA==}
     engines: {node: '>=10.0.0'}
     hasBin: true
     optionalDependencies:
@@ -3990,7 +3741,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.4
-      es-abstract: 1.20.1
+      es-abstract: 1.20.2
       get-intrinsic: 1.1.2
       has-symbols: 1.0.3
       internal-slot: 1.0.3
@@ -4003,7 +3754,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.4
-      es-abstract: 1.20.1
+      es-abstract: 1.20.2
     dev: true
 
   /string.prototype.trimstart/1.0.5:
@@ -4011,7 +3762,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.4
-      es-abstract: 1.20.1
+      es-abstract: 1.20.2
     dev: true
 
   /strip-ansi/6.0.1:
@@ -4107,6 +3858,10 @@ packages:
       any-promise: 1.3.0
     dev: true
 
+  /tinybench/2.1.5:
+    resolution: {integrity: sha512-ak+PZZEuH3mw6CCFOgf5S90YH0MARnZNhxjhjguAmoJimEMAJuNip/rJRd6/wyylHItomVpKTzZk9zrhTrQCoQ==}
+    dev: true
+
   /tinypool/0.2.4:
     resolution: {integrity: sha512-Vs3rhkUH6Qq1t5bqtb816oT+HeJTXfwt2cbPH17sWHIYKTotQIFPk3tf2fgqRrVyMDVOc1EnPgzIxfIulXVzwQ==}
     engines: {node: '>=14.0.0'}
@@ -4160,7 +3915,7 @@ packages:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
     dev: true
 
-  /tsup/6.2.3_typescript@4.8.2:
+  /tsup/6.2.3_typescript@4.8.3:
     resolution: {integrity: sha512-J5Pu2Dx0E1wlpIEsVFv9ryzP1pZ1OYsJ2cBHZ7GrKteytNdzaSz5hmLX7/nAxtypq+jVkVvA79d7S83ETgHQ5w==}
     engines: {node: '>=14'}
     hasBin: true
@@ -4176,34 +3931,34 @@ packages:
       typescript:
         optional: true
     dependencies:
-      bundle-require: 3.1.0_esbuild@0.15.6
+      bundle-require: 3.1.0_esbuild@0.15.7
       cac: 6.7.14
       chokidar: 3.5.3
       debug: 4.3.4
-      esbuild: 0.15.6
+      esbuild: 0.15.7
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
       postcss-load-config: 3.1.4
       resolve-from: 5.0.0
-      rollup: 2.78.1
+      rollup: 2.79.0
       source-map: 0.8.0-beta.0
       sucrase: 3.25.0
       tree-kill: 1.2.2
-      typescript: 4.8.2
+      typescript: 4.8.3
     transitivePeerDependencies:
       - supports-color
       - ts-node
     dev: true
 
-  /tsutils/3.21.0_typescript@4.8.2:
+  /tsutils/3.21.0_typescript@4.8.3:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 4.8.2
+      typescript: 4.8.3
     dev: true
 
   /tsx/3.9.0:
@@ -4244,8 +3999,8 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /typescript/4.8.2:
-    resolution: {integrity: sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==}
+  /typescript/4.8.3:
+    resolution: {integrity: sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==}
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: true
@@ -4477,8 +4232,8 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /vite/3.0.9:
-    resolution: {integrity: sha512-waYABTM+G6DBTCpYAxvevpG50UOlZuynR0ckTK5PawNVt7ebX6X7wNXHaGIO6wYYFXSM7/WcuFuO2QzhBB6aMw==}
+  /vite/3.1.0:
+    resolution: {integrity: sha512-YBg3dUicDpDWFCGttmvMbVyS9ydjntwEjwXRj2KBFwSB8SxmGcudo1yb8FW5+M/G86aS8x828ujnzUVdsLjs9g==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
     peerDependencies:
@@ -4496,16 +4251,16 @@ packages:
       terser:
         optional: true
     dependencies:
-      esbuild: 0.14.54
+      esbuild: 0.15.7
       postcss: 8.4.16
       resolve: 1.22.1
-      rollup: 2.77.3
+      rollup: 2.78.1
     optionalDependencies:
       fsevents: 2.3.2
     dev: true
 
-  /vitest/0.22.1_@vitest+ui@0.22.1:
-    resolution: {integrity: sha512-+x28YTnSLth4KbXg7MCzoDAzPJlJex7YgiZbUh6YLp0/4PqVZ7q7/zyfdL0OaPtKTpNiQFPpMC8Y2MSzk8F7dw==}
+  /vitest/0.23.1_@vitest+ui@0.23.1:
+    resolution: {integrity: sha512-kn9pG+h6VA3yj/xRvwgLKEd33rOlzMqJEg3tl5HSm3WUPlkY1Lr1FK8RN1uIqVKvFxmz6HGU3EQW+xW2kazRkQ==}
     engines: {node: '>=v14.16.0'}
     hasBin: true
     peerDependencies:
@@ -4528,14 +4283,16 @@ packages:
     dependencies:
       '@types/chai': 4.3.3
       '@types/chai-subset': 1.3.3
-      '@types/node': 18.7.14
-      '@vitest/ui': 0.22.1
+      '@types/node': 18.7.16
+      '@vitest/ui': 0.23.1
       chai: 4.3.6
       debug: 4.3.4
       local-pkg: 0.4.2
+      strip-literal: 0.4.0
+      tinybench: 2.1.5
       tinypool: 0.2.4
       tinyspy: 1.0.2
-      vite: 3.0.9
+      vite: 3.1.0
     transitivePeerDependencies:
       - less
       - sass
@@ -4558,8 +4315,8 @@ packages:
     dependencies:
       vue: 3.2.37
 
-  /vue-eslint-parser/9.0.3_eslint@8.23.0:
-    resolution: {integrity: sha512-yL+ZDb+9T0ELG4VIFo/2anAOz8SvBdlqEnQnvJ3M7Scq56DvtjY0VY88bByRZB0D4J0u8olBcfrXTVONXsh4og==}
+  /vue-eslint-parser/9.1.0_eslint@8.23.0:
+    resolution: {integrity: sha512-NGn/iQy8/Wb7RrRa4aRkokyCZfOUWk19OP5HP6JEozQFX5AoS/t+Z0ZN7FY4LlmWc4FNI922V7cvX28zctN8dQ==}
     engines: {node: ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: '>=6.0.0'
@@ -4585,14 +4342,14 @@ packages:
       '@vue/server-renderer': 3.2.37_vue@3.2.37
       '@vue/shared': 3.2.37
 
-  /vue/3.2.38:
-    resolution: {integrity: sha512-hHrScEFSmDAWL0cwO4B6WO7D3sALZPbfuThDsGBebthrNlDxdJZpGR3WB87VbjpPh96mep1+KzukYEhpHDFa8Q==}
+  /vue/3.2.39:
+    resolution: {integrity: sha512-tRkguhRTw9NmIPXhzk21YFBqXHT2t+6C6wPOgQ50fcFVWnPdetmRqbmySRHznrYjX2E47u0cGlKGcxKZJ38R/g==}
     dependencies:
-      '@vue/compiler-dom': 3.2.38
-      '@vue/compiler-sfc': 3.2.38
-      '@vue/runtime-dom': 3.2.38
-      '@vue/server-renderer': 3.2.38_vue@3.2.38
-      '@vue/shared': 3.2.38
+      '@vue/compiler-dom': 3.2.39
+      '@vue/compiler-sfc': 3.2.39
+      '@vue/runtime-dom': 3.2.39
+      '@vue/server-renderer': 3.2.39_vue@3.2.39
+      '@vue/shared': 3.2.39
     dev: true
 
   /webidl-conversions/4.0.2:

--- a/src/core/ast.ts
+++ b/src/core/ast.ts
@@ -25,6 +25,7 @@ import type {
   TSTypes,
 } from './utils'
 import {
+  at,
   convertExportsToImports,
   debuggerFactory,
   getAst,
@@ -503,7 +504,7 @@ export async function extractTypesFromSource(
   }
 
   function unwrapPath(key: NameWithPath): string {
-    return key.split(':').at(-1)!
+    return at(key.split(':'), -1)
   }
 
   function setNamesMap(fullName: FullName, nameWithPath: NameWithPath) {
@@ -632,7 +633,7 @@ export async function extractTypesFromSource(
       const arr = m[2].split('_')
 
       // Remove prefix if exists
-      if (isNumber(parseInt(arr.at(-1)!)))
+      if (isNumber(parseInt(at(arr, -1))))
         arr.pop()
 
       result = arr.join('_')
@@ -1078,7 +1079,7 @@ export async function extractTypesFromSource(
 
     const { hasDuplicateImports, referenceSource } = (getMetaData(enumName) || {}) as ReferenceTypeMetaData
 
-    const referenceSourceFile = referenceSource.split(':').at(-2)!
+    const referenceSourceFile = at(referenceSource.split(':'), -2)
 
     // Remove extra specifier if it is referenced from SFC
     if (/\.vue$/.test(referenceSourceFile)) {

--- a/src/core/ast.ts
+++ b/src/core/ast.ts
@@ -15,11 +15,9 @@ import type {
   TSTypeReference,
   TSUnionType,
 } from '@babel/types'
-import { generateCodeFrame } from '@vue/compiler-sfc'
 import type {
   FullName,
   GroupedImports,
-  LocationMap,
   MaybeAliases,
   MaybeNumber,
   NameWithPath,
@@ -40,11 +38,9 @@ import {
   isTSTypes,
   isWithDefaults,
   resolveModulePath,
-  warn,
 } from './utils'
-import { LogMsg } from './constants'
 
-enum Prefixes {
+const enum Prefixes {
   Default = '_VTI_TYPE_',
   Empty = '',
 }
@@ -294,17 +290,26 @@ function extractAllTypescriptTypesFromAST(ast: Program): Record<'local' | 'expor
   }
 }
 
-export interface TypeMetaData {
-  // The source type which reference this
+export interface LocalTypeMetaData {
+  // The source type which reference current type
   referenceSource?: string
-  replacementIndex?: number
-  dependencyIndex?: number
-  // metadata for interfaces
-  sourceInterfaceName?: string
-  isProperty?: boolean
+  // The interface which extends current interface
+  extendTarget?: string
   // Whether it is used in vue macros
   isUsedType?: boolean
+  hasDuplicateImports?: boolean
 }
+
+export interface ReplacementRecord {
+  target: FullName
+  source: NameWithPath
+}
+
+export type TypeMetaData = Omit<LocalTypeMetaData, 'referenceSource'> & {
+  replacementTargets?: ReplacementRecord[]
+}
+
+export type ReferenceTypeMetaData = LocalTypeMetaData & { referenceSource: NameWithPath }
 
 export interface ExtractedTypeReplacement {
   offset: number
@@ -326,6 +331,7 @@ export interface ExtractTypesFromSourceOptions {
   metaDataMap: Record<string, TypeMetaData>
   extractAliases?: Record<string, string>
   // Data shared across recursions
+  extraSpecifiers?: string[]
   extractedKeysCounter?: Record<string, number>
   extractedNamesMap?: Record<FullName, NameWithPath>
   extractedTypes?: ExtractedTypes
@@ -344,6 +350,20 @@ export interface ExtractResult {
   importNodes: ImportDeclaration[]
   extraSpecifiers: string[]
   sourceReplacements: Replacement[]
+}
+
+interface PreExtractionOptions {
+  name: string
+  metaData: ReferenceTypeMetaData
+  replaceLocation: Omit<Replacement, 'replacement'>
+}
+
+interface PostExtractionOptions {
+  key: NameWithPath
+  name: string
+  fullName: FullName
+  metaData: LocalTypeMetaData
+  isEnum?: boolean
 }
 
 /**
@@ -365,6 +385,7 @@ export async function extractTypesFromSource(
     extractedTypes = new Map<NameWithPath, ExtractedTypeInfo>(),
     extractedTypeReplacements = {},
     interfaceExtendsRecord = {},
+    extraSpecifiers = [],
 
     ast = getAst(source),
     isInSFC = false,
@@ -372,15 +393,18 @@ export async function extractTypesFromSource(
 
   const debug = createAstDebugger('extractTypesFromSource')
 
-  debug('In SFC: %o', isInSFC)
-  debug('Types to find: %o', types)
-  debug('Metadata Map: %O', metaDataMap)
-  debug('Extract aliases: %O', extractAliases)
-
   const missingTypes: Record<'local' | 'requested', string[]> = {
     local: [],
     requested: [],
   }
+
+  const localMetaDataMap: Record<string, LocalTypeMetaData | undefined> = metaDataMap
+  const replacementRecord: Record<string, ReplacementRecord[]> = {}
+
+  debug('In SFC: %o', isInSFC)
+  debug('Types to find: %o', types)
+  debug('Local metadata map: %O', localMetaDataMap)
+  debug('Extract aliases: %O', extractAliases)
 
   // Get external types
   const { imports, importNodes } = getAvailableImportsFromAst(ast)
@@ -388,7 +412,6 @@ export async function extractTypesFromSource(
   const { namedExports, namedFromExports } = getAvailableExportsFromAst(ast)
 
   debug('Relative path: %s', relativePath)
-  debug('Source: %s', source)
   debug('Counter: %O', extractedKeysCounter)
 
   // Categorize imports
@@ -396,72 +419,69 @@ export async function extractTypesFromSource(
 
   const { localNodeMap, exportedNodeMap } = getTSNodeMap(extractAllTypescriptTypesFromAST(ast), namedExports)
 
-  let hasRedundantExportAliasWarning = false
+  // local -> exported[]
+  const exportAliasRecord: Record<string, string[]> = {}
 
-  // localSpecifier -> locationInfo
-  const exportedAliasLocationMap: LocationMap = {}
-
+  // exported -> local
   const exportAliases = namedExports.reduce<Record<string, string>>((res, e) => {
-    if (e.local !== e.exported) {
+    if (e.local !== e.exported)
       res[e.exported] = e.local
-
-      exportedAliasLocationMap[e.local] = {
-        start: e.start,
-        end: e.end,
-      }
-
-      patchDataFromName(e.local, e.exported)
-    }
 
     return res
   }, {})
 
   debug('Export aliases: %O', exportAliases)
 
-  const reversedExportAliases = Object.entries(exportAliases).reduce<Record<string, string>>((res, [exported, local]) => {
-    const alias = res[local]
+  // local -> exported
+  const reversedExportAliases = types.reduce<Record<string, string>>((res, maybeAlias) => {
+    const localName = exportAliases[maybeAlias]
 
-    if (isString(alias)) {
-      const loc = exportedAliasLocationMap[local]
-
-      hasRedundantExportAliasWarning = true
-
-      warn(`ExportAlias "${exported}" is redundant because there is already an ExportAlias that exports the same type. ${LogMsg.UNEXPECTED_RESULT} ${LogMsg.SUGGEST_TYPE_ALIAS}`, {
-        fileName: relativePath,
-        codeFrame: generateCodeFrame(source, loc.start, loc.end),
-      })
+    if (!localName) {
+      // Skip when it is exactly the local name
+      return res
     }
 
-    res[local] = exported
+    const alias = res[localName]
+
+    // Add replacements to the existing's if we have already found an alias
+    if (isString(alias)) {
+      debug('Add replacements of %s to %s', maybeAlias, localName)
+
+      const targetRecord = getSharedMetaData(localName)!.replacementTargets!
+
+      const sourceRecord = getSharedMetaData(maybeAlias)!.replacementTargets!
+
+      targetRecord.push(...sourceRecord)
+    }
+    else {
+      res[localName] = maybeAlias
+
+      patchDataFromName(localName, maybeAlias)
+    }
+
+    exportAliasRecord[localName] ||= []
+    exportAliasRecord[localName].push(maybeAlias)
 
     return res
   }, {})
 
-  debug('Reversed export aliases: %O', reversedExportAliases)
-
-  // Apply export aliases (exported -> local) to find types (and dedupe them)
-  const processedTypes = Object.keys(types.reduce<Record<string, string>>((res, _name) => {
-    const name = exportAliases[_name] || _name
-    const value = res[name]
-
-    if (isString(value) && !hasRedundantExportAliasWarning) {
-      const loc = exportedAliasLocationMap[_name]
-
-      warn(`ExportSpecifier "${_name}" is redundant because there is already an ExportSpecifier that exports the same type. ${LogMsg.UNEXPECTED_RESULT} ${LogMsg.SUGGEST_TYPE_ALIAS}`, {
-        fileName: relativePath,
-        codeFrame: generateCodeFrame(source, loc.start, loc.end),
+  Object.entries(exportAliasRecord).forEach(([typeName, record]) => {
+    // Add metadata if it has multiple aliases
+    if (record.length > 1) {
+      setMetaData(typeName, {
+        hasDuplicateImports: true,
       })
     }
+  })
 
-    res[name] = name
+  debug('Reversed export aliases: %O', reversedExportAliases)
 
-    return res
-  }, {}))
+  // Unwrap export aliases (exported -> local) to find types (and dedupe them)
+  const processedTypes = [...new Set(types.map(name => exportAliases[name] || name))]
 
   debug('Processed types: %O', processedTypes)
 
   // SFC only variables (i.e. It will only be used in the first recursion)
-  const extraSpecifiers: string[] = []
   const sourceReplacements: Replacement[] = []
 
   const extractFromPosition = (start: MaybeNumber, end: MaybeNumber) =>
@@ -478,8 +498,12 @@ export async function extractTypesFromSource(
     return extractAliases[name] || name
   }
 
-  function withPath(name: string): string {
+  function withPath(name: string): NameWithPath {
     return `${relativePath}:${name}`
+  }
+
+  function unwrapPath(key: NameWithPath): string {
+    return key.split(':').at(-1)!
   }
 
   function setNamesMap(fullName: FullName, nameWithPath: NameWithPath) {
@@ -487,24 +511,67 @@ export async function extractTypesFromSource(
     extractedNamesMap[fullName] = nameWithPath
   }
 
-  function getMetaData(name: string): TypeMetaData | undefined {
-    return metaDataMap[name]
+  function getSharedMetaData(name: string): TypeMetaData | undefined {
+    return localMetaDataMap[name]
   }
 
-  function setMetaData(name: string, val: TypeMetaData): void {
-    const metaData = metaDataMap[name]
+  function getMetaData(name: string): LocalTypeMetaData | undefined {
+    return localMetaDataMap[name]
+  }
 
-    if (metaData)
-      debug('Override metadata: %s => %O => %O', name, metaData, val)
-    else
+  function getReplacementRecord(name: string): ReplacementRecord[] | undefined {
+    return getSharedMetaData(name)!.replacementTargets
+  }
+
+  function setMetaData(name: string, val: LocalTypeMetaData): LocalTypeMetaData {
+    const metaData = localMetaDataMap[name]
+
+    if (metaData) {
+      const mergedMetaData: LocalTypeMetaData = {
+        ...metaData,
+        ...val,
+      }
+
+      debug('Overriding metadata: %s => %O => %O', name, metaData, mergedMetaData)
+      return localMetaDataMap[name] = mergedMetaData
+    }
+    else {
       debug('Set metadata: %s => %O', name, val)
+      return localMetaDataMap[name] = val
+    }
+  }
 
-    metaDataMap[name] = val
+  function deleteMetaData(name: string) {
+    debug('Delete metadata %s', name)
+    localMetaDataMap[name] = undefined
   }
 
   function patchDataFromName(name: string, from: string) {
     debug('Patching data for %s from %s', name, from)
-    setMetaData(name, getMetaData(from)!)
+
+    const sourceRecord = getSharedMetaData(name)?.replacementTargets
+
+    const targetRecord = (setMetaData(name, getSharedMetaData(from)!) as TypeMetaData).replacementTargets!
+
+    deleteMetaData(from)
+
+    /**
+     * If sourceRecord exists, it means that user also imported the original (local) name of the type
+     * @example
+     * ```typescript
+     * import { Foo, Bar } from './foo'
+     * ```
+     * foo.ts
+     * ```typescript
+     * export { Foo, Foo as Bar }
+     * ```
+     */
+    if (sourceRecord?.length) {
+      targetRecord.push(...sourceRecord)
+
+      exportAliasRecord[name] ||= []
+      exportAliasRecord[name].push(name)
+    }
 
     extractAliases[name] = extractAliases[from] || from
   }
@@ -554,18 +621,78 @@ export async function extractTypesFromSource(
     return result
   }
 
-  function addTypeReplacement(key: string, replacement: Replacement): number {
-    debug('Add type replacement: %s => %O', key, replacement)
+  function convertFullNameToName(fullName: FullName): string {
+    const fullNameRE = /(_VTI_TYPE_)?([\w\d$_]+)/g
 
-    return extractedTypeReplacements[key].replacements.push(replacement) - 1
+    const matches = fullName.matchAll(fullNameRE)
+
+    let result = ''
+
+    for (const m of matches) {
+      const arr = m[2].split('_')
+
+      // Remove prefix if exists
+      if (isNumber(parseInt(arr.at(-1)!)))
+        arr.pop()
+
+      result = arr.join('_')
+    }
+
+    return result
   }
 
-  function addDependencyToType(key: string, dependency: string): number {
+  function addReplacementRecord(name: string, record: ReplacementRecord) {
+    debug('Add replacement record: %s -> %O', name, record)
+
+    replacementRecord[name] ||= []
+
+    replacementRecord[name].push(record)
+  }
+
+  function addTypeReplacement(key: string, replacement: Replacement) {
+    debug('Add type replacement: %s => %O', key, replacement)
+
+    extractedTypeReplacements[key].replacements.push(replacement)
+  }
+
+  function addDependencyToType(key: string, dependency: string) {
     debug('Add dependency: %s => %s', key, dependency)
 
     const extractedTypeInfo = extractedTypes.get(key)!
 
-    return extractedTypeInfo.dependencies!.push(dependency) - 1
+    extractedTypeInfo.dependencies!.push(dependency)
+  }
+
+  // Change the name (the content of replacements) to the already extracted's
+  function changeReplacementContent(replacementRecord: ReplacementRecord[], fullName: FullName) {
+    const record: Record<string, string[]> = {}
+
+    replacementRecord.forEach(({ target, source }) => {
+      if (target === fullName || record[source]?.includes(target))
+        return
+
+      record[source] ||= []
+      record[source].push(target)
+
+      const sourceTypeInfo = extractedTypes.get(source)!
+
+      const replacement = extractedTypeReplacements[source]
+
+      replacement.replacements = replacement.replacements.map<Replacement>((r) => {
+        if (r.replacement === target) {
+          debug('Change name: %s -> %s', r.replacement, fullName)
+
+          return {
+            ...r,
+            replacement: fullName,
+          }
+        }
+
+        return r
+      })
+
+      sourceTypeInfo.dependencies = sourceTypeInfo.dependencies!.map(dep => dep === target ? fullName : dep)
+    })
   }
 
   function removeTypeFromSource(node: Exclude<TSTypes, TSEnumDeclaration>) {
@@ -631,7 +758,7 @@ export async function extractTypesFromSource(
   function extractTypeByName(_name: string) {
     const name = _name
 
-    const { referenceSource, replacementIndex, dependencyIndex } = metaDataMap[name] || {}
+    const replacementRecord = getReplacementRecord(name)
 
     const key = withPath(name)
 
@@ -639,16 +766,10 @@ export async function extractTypesFromSource(
     if (extractedTypes.has(key)) {
       debug('Skipping type: %s', name)
 
-      // Change the name to the already extracted's
-      if (referenceSource) {
+      if (replacementRecord?.length) {
         const { fullName } = extractedTypes.get(key)!
 
-        const replacements = extractedTypeReplacements[referenceSource].replacements
-        const dependencies = extractedTypes.get(referenceSource)!.dependencies!
-
-        replacements[replacementIndex!].replacement = fullName
-        dependencies[dependencyIndex!] = fullName
-        debug('Change name: %s -> %s', name, fullName)
+        changeReplacementContent(replacementRecord, fullName)
       }
 
       return
@@ -659,13 +780,21 @@ export async function extractTypesFromSource(
     if (node) {
       const fullName = getFullName(name)
 
+      /**
+       * NOTE(zorin): Remove types from source if we are extracting types in SFC (except enum types),
+       * because we need to make sure the order is correct
+       */
       if (isInSFC && !isEnum(node))
         removeTypeFromSource(node)
 
       ExtractTypeByNode(node, fullName)
     }
     else {
-      const name = reversedExportAliases[_name] || _name
+      const exportedName = reversedExportAliases[_name]
+      const name = exportedName || _name
+
+      if (isString(exportedName))
+        setMetaData(exportedName, getMetaData(_name)!)
 
       if (isInSFC)
         extraSpecifiers.push(name)
@@ -702,36 +831,70 @@ export async function extractTypesFromSource(
       extractedTypeReplacements,
       interfaceExtendsRecord,
       metaDataMap,
+      extraSpecifiers,
     })
   }
 
-  const extractTypesFromTSUnionType = (union: TSUnionType, metaData: TypeMetaData) => {
+  function preReferenceExtraction(options: PreExtractionOptions): void {
+    const { name, replaceLocation, metaData } = options
+
     const { referenceSource } = metaData
 
-    let replacementIndex: number | undefined
-    let dependencyIndex: number | undefined
+    const fullName = getFullName(name)
+
+    addTypeReplacement(referenceSource, {
+      start: replaceLocation.start,
+      end: replaceLocation.end,
+      replacement: fullName,
+    })
+
+    addReplacementRecord(name, {
+      target: fullName,
+      source: referenceSource,
+    })
+
+    addDependencyToType(referenceSource, fullName)
+
+    setMetaData(name, metaData)
+  }
+
+  function postExtraction(options: PostExtractionOptions): void {
+    const { key, name, fullName, isEnum, metaData: { isUsedType, hasDuplicateImports } } = options
+
+    setNamesMap(fullName, key)
+
+    /**
+     * NOTE(zorin):Always add count for enum types
+     * There are 2 reasons:
+     * 1. I don't think users will use enum types in vue macros
+     * 2. Whether they are declared in SFC or not, their names will always be prefixed (Because users may use them as values)
+     *
+     * Also, we don't need to add count for types used directly in vue macros or types declared in SFC
+     * because they are not prefixed
+     */
+    if (isEnum || !(isUsedType || isInSFC))
+      addCount(name)
+
+    if (hasDuplicateImports)
+      changeReplacementContent(getReplacementRecord(name)!, fullName)
+  }
+
+  const extractTypesFromTSUnionType = (union: TSUnionType, metaData: ReferenceTypeMetaData) => {
+    const referenceSourceName = unwrapPath(metaData.referenceSource)
 
     union.types
       .filter((n): n is TSTypeReference => n.type === 'TSTypeReference')
       .forEach((typeReference) => {
-        if (typeReference.typeName.type === 'Identifier') {
+        if (typeReference.typeName.type === 'Identifier' && typeReference.typeName.name !== referenceSourceName) {
           const name = typeReference.typeName.name
-          const referenceFullName = getFullName(name)
 
-          if (referenceSource) {
-            replacementIndex = addTypeReplacement(referenceSource!, {
+          preReferenceExtraction({
+            name,
+            replaceLocation: {
               start: typeReference.start!,
               end: typeReference.end!,
-              replacement: referenceFullName,
-            })
-
-            dependencyIndex = addDependencyToType(referenceSource!, referenceFullName)
-          }
-
-          setMetaData(name, {
-            ...metaData,
-            replacementIndex,
-            dependencyIndex,
+            },
+            metaData: { ...metaData },
           })
 
           extractTypeByName(name)
@@ -739,7 +902,7 @@ export async function extractTypesFromSource(
       })
   }
 
-  function extractExtendInterfaces(interfaces: TSExpressionWithTypeArguments[], metaData: TypeMetaData) {
+  function extractExtendInterfaces(interfaces: TSExpressionWithTypeArguments[], metaData: LocalTypeMetaData) {
     for (const extend of interfaces) {
       if (extend.expression.type === 'Identifier') {
         const name = extend.expression.name
@@ -763,21 +926,7 @@ export async function extractTypesFromSource(
     const interfaceName = node.id.name
     const key = withPath(interfaceName)
 
-    const { sourceInterfaceName, isProperty, isUsedType } = getMetaData(interfaceName) || {}
-
-    // Skip all process, since Vue only transform the type of nested objects to 'Object'
-    if (isProperty) {
-      extractedTypes.set(key, {
-        typeKeyword: 'interface',
-        fullName,
-        body: '{}',
-      })
-
-      setNamesMap(fullName, key)
-
-      addCount(interfaceName)
-      return
-    }
+    const { extendTarget, isUsedType, hasDuplicateImports } = getMetaData(interfaceName) || {}
 
     const bodyStart = node.body.start!
     const bodyEnd = node.body.end!
@@ -792,30 +941,31 @@ export async function extractTypesFromSource(
       dependencies: [],
     })
 
-    setNamesMap(fullName, key)
+    postExtraction({
+      key,
+      fullName,
+      name: interfaceName,
+      metaData: {
+        isUsedType,
+        hasDuplicateImports,
+      },
+    })
 
-    /**
-     * NOTE(zorin): We don't need to add count for types used directly in vue macros or types declared in SFC
-     * because they are not prefixed
-     */
-    if (!(isUsedType || isInSFC))
-      addCount(interfaceName)
-
-    if (sourceInterfaceName) {
+    if (extendTarget) {
       /**
-       * NOTE(zorin): If the record does not exist, it means that the source interface comes from another file
+       * NOTE(zorin): If the record does not exist, it means that the interface which extends current interface comes from another file
        * So we need to initialize it
        */
-      interfaceExtendsRecord[sourceInterfaceName] ||= []
+      interfaceExtendsRecord[extendTarget] ||= []
 
-      interfaceExtendsRecord[sourceInterfaceName].push(key)
+      interfaceExtendsRecord[extendTarget].push(key)
     }
 
     if (extendsInterfaces) {
       interfaceExtendsRecord[key] = []
 
       extractExtendInterfaces(extendsInterfaces, {
-        sourceInterfaceName: key,
+        extendTarget: key,
       })
     }
 
@@ -835,29 +985,24 @@ export async function extractTypesFromSource(
         if (typeAnnotation?.type === 'TSUnionType') {
           extractTypesFromTSUnionType(typeAnnotation, {
             referenceSource: key,
-            isProperty: true,
           })
         }
         else if (
           typeAnnotation?.type === 'TSTypeReference'
           && typeAnnotation.typeName.type === 'Identifier'
+          && typeAnnotation.typeName.name !== interfaceName
         ) {
           const name = typeAnnotation.typeName.name
-          const referenceFullName = getFullName(name)
 
-          const replacementIndex = addTypeReplacement(key, {
-            start: typeAnnotation.start!,
-            end: typeAnnotation.end!,
-            replacement: referenceFullName,
-          })
-
-          const dependencyIndex = addDependencyToType(key, referenceFullName)
-
-          setMetaData(name, {
-            referenceSource: key,
-            replacementIndex,
-            dependencyIndex,
-            isProperty: true,
+          preReferenceExtraction({
+            name,
+            replaceLocation: {
+              start: typeAnnotation.start!,
+              end: typeAnnotation.end!,
+            },
+            metaData: {
+              referenceSource: key,
+            },
           })
 
           extractTypeByName(name)
@@ -874,7 +1019,7 @@ export async function extractTypesFromSource(
     const key = withPath(typeAliasName)
     const typeAnnotation = node.typeAnnotation
 
-    const { isUsedType } = metaDataMap[typeAliasName] || {}
+    const { isUsedType, hasDuplicateImports } = getMetaData(typeAliasName) || {}
 
     extractedTypes.set(key, {
       typeKeyword: 'type',
@@ -883,14 +1028,15 @@ export async function extractTypesFromSource(
       dependencies: [],
     })
 
-    setNamesMap(fullName, key)
-
-    /**
-     * NOTE(zorin): We don't need to add count for types used directly in vue macros or types declared in SFC
-     * because they are not prefixed
-     */
-    if (!(isUsedType || isInSFC))
-      addCount(typeAliasName)
+    postExtraction({
+      key,
+      fullName,
+      name: typeAliasName,
+      metaData: {
+        isUsedType,
+        hasDuplicateImports,
+      },
+    })
 
     extractedTypeReplacements[key] = {
       offset: -typeAnnotation.start!,
@@ -903,20 +1049,16 @@ export async function extractTypesFromSource(
     // TODO(zorin): Support TSLiteral, IntersectionType
     else if (typeAnnotation.type === 'TSTypeReference' && typeAnnotation.typeName.type === 'Identifier') {
       const name = typeAnnotation.typeName.name
-      const referenceFullName = getFullName(name)
 
-      const replacementIndex = addTypeReplacement(key, {
-        start: typeAnnotation.typeName.start!,
-        end: typeAnnotation.typeName.end!,
-        replacement: referenceFullName,
-      })
-
-      const dependencyIndex = addDependencyToType(key, referenceFullName)
-
-      setMetaData(name, {
-        referenceSource: key,
-        replacementIndex,
-        dependencyIndex,
+      preReferenceExtraction({
+        name,
+        replaceLocation: {
+          start: typeAnnotation.typeName.start!,
+          end: typeAnnotation.typeName.end!,
+        },
+        metaData: {
+          referenceSource: key,
+        },
       })
 
       extractTypeByName(name)
@@ -934,6 +1076,22 @@ export async function extractTypesFromSource(
     const key = withPath(enumName)
     const enumTypes: Set<string> = new Set()
 
+    const { hasDuplicateImports, referenceSource } = (getMetaData(enumName) || {}) as ReferenceTypeMetaData
+
+    const referenceSourceFile = referenceSource.split(':').at(-2)!
+
+    // Remove extra specifier if it is referenced from SFC
+    if (/\.vue$/.test(referenceSourceFile)) {
+      const name = convertFullNameToName(fullName)
+
+      if (name) {
+        extraSpecifiers.forEach((specifier, idx) => {
+          if (specifier === name)
+            extraSpecifiers.splice(idx, 1)
+        })
+      }
+    }
+
     // (semi-stable) Determine the type of enum, may not be able to process the use of complex scenes
     for (const member of node.members) {
       if (member.initializer) {
@@ -947,38 +1105,50 @@ export async function extractTypesFromSource(
       }
     }
 
+    const result = [...enumTypes].join(' | ')
+
+    let body = '/* enum */ '
+
+    if (result)
+      body += result
+    else
+      body = '/* empty-enum */ number | string'
+
     extractedTypes.set(key, {
       typeKeyword: 'type',
       fullName,
-      body: `${[...enumTypes].join(' | ') || 'number | string'};`,
+      body,
     })
 
-    setNamesMap(fullName, key)
-
-    /**
-     * NOTE(zorin): Always add count for enum types
-     * There are 2 reasons:
-     * 1. I don't think users will use enum types in vue macros
-     * 2. Whether they are declared in SFC or not, their names will always be prefixed (Because users may use them as values)
-     */
-    addCount(enumName)
+    postExtraction({
+      key,
+      fullName,
+      name: enumName,
+      metaData: {
+        hasDuplicateImports,
+      },
+      isEnum: true,
+    })
   }
 
+  /**
+   * TODO(zorin): Remove corresponding replacements and dependencies if we could not find the type
+   */
   async function findMissingTypes(missingTypes: string[], groupedImports: GroupedImports) {
     debug('Missing types: %O', missingTypes)
     debug('Grouped imports: %O', groupedImports)
 
     for (const [modulePath, importInfo] of Object.entries(groupedImports)) {
-      // Get intersection (it will dedupe the elements)
+      // Get intersection (it will also dedupe the elements)
       const intersection = intersect(importInfo.localSpecifiers, missingTypes)
 
       debug('Intersection: %O', intersection)
 
       if (intersection.length) {
         const moduleImportAliases = importInfo.aliases
-        const locationMap = importInfo.locationMap
 
-        let hasRedundantAliasWarning = false
+        // imported -> local[]
+        const importAliasRecord: Record<string, string[]> = {}
 
         // Generate new extract aliases (originalName -> userAlias) to replace the name of types
         const newExtractAliases = intersection.reduce<Record<string, string>>((res, maybeAlias) => {
@@ -986,8 +1156,9 @@ export async function extractTypesFromSource(
 
           if (!originalName) {
             /**
-             * NOTE(zorin): Apply alias for `import { default as default } from 'foo'`
-             * In theory, this kind of syntax is only produced by the plugin
+             * NOTE(zorin): Apply alias for `import { default } from 'foo'`
+             * In theory, this kind of syntax is only produced by the plugin (Users will get errors from TS if they write this kind of code)
+             * The plugin converts `export { default } from 'foo'` to `import { default } from 'foo';export { default }`
              */
             if (maybeAlias === 'default') {
               const alias = extractAliases.default
@@ -1001,42 +1172,78 @@ export async function extractTypesFromSource(
 
           const alias = res[originalName]
 
+          // Add replacements to the existing's if we have already found an alias
           if (isString(alias)) {
-            const loc = locationMap[maybeAlias]
+            debug('Add replacements of %s to %s', maybeAlias, alias)
 
-            hasRedundantAliasWarning = true
+            const targetRecord = replacementRecord[alias] || getSharedMetaData(alias)!.replacementTargets!
 
-            warn(`ImportAlias "${maybeAlias}" is redundant because there is already an ImportAlias that imports the same type. ${LogMsg.UNEXPECTED_RESULT} ${LogMsg.SUGGEST_TYPE_ALIAS}`, {
-              fileName: relativePath,
-              codeFrame: generateCodeFrame(source, loc.start, loc.end),
-            })
+            const sourceRecord = replacementRecord[maybeAlias] || getSharedMetaData(maybeAlias)!.replacementTargets!
+
+            targetRecord.push(...sourceRecord)
+          }
+          else {
+            res[originalName] = maybeAlias
           }
 
-          res[originalName] = maybeAlias
+          importAliasRecord[originalName] ||= []
+          importAliasRecord[originalName].push(maybeAlias)
 
           return res
         }, {})
 
+        Object.entries(importAliasRecord).forEach(([typeName, record]) => {
+          // Add metadata if it has multiple aliases
+          if (record.length > 1) {
+            const alias = newExtractAliases[typeName]
+
+            setMetaData(alias, {
+              hasDuplicateImports: true,
+            })
+          }
+        })
+
         debug('New extract aliases: %O', newExtractAliases)
 
-        // Apply aliases (userAlias -> originalName) to find types (and dedupe them)
-        const processedIntersection = Object.keys(intersection.reduce<Record<string, string>>((res, _name) => {
+        // Apply aliases and record the number of times each type appears (also we dedupe them in this step)
+        const typeCounter = intersection.reduce<Record<string, number>>((counter, _name) => {
           const name = moduleImportAliases[_name] || _name
-          const value = res[name]
 
-          if (isString(value) && !hasRedundantAliasWarning) {
-            const loc = locationMap[_name]
+          counter[name] ??= 0
 
-            warn(`ImportSpecifier "${_name}" is redundant because there is already an ImportSpecifier that imports the same type. ${LogMsg.UNEXPECTED_RESULT} ${LogMsg.SUGGEST_TYPE_ALIAS}`, {
-              fileName: relativePath,
-              codeFrame: generateCodeFrame(source, loc.start, loc.end),
+          counter[name] += 1
+
+          return counter
+        }, {})
+
+        // Unwrap aliases (userAlias -> originalName) to find types
+        const processedIntersection = Object.entries(typeCounter).map(([typeName, count]) => {
+          /**
+           * If the type has duplicate imports and its number does not match the number of its aliases,
+           * it means that the user also imported the original(exported) name of the type
+           * @example
+           * ```typescript
+           * import { Foo, Foo as Bar } from 'foo'
+           * ```
+           */
+          if (count > 1 && count !== importAliasRecord[typeName].length) {
+            const alias = newExtractAliases[typeName]
+
+            debug('Push replacements of %s to %s (Original)', typeName, alias)
+
+            const targetRecord = replacementRecord[alias] || getSharedMetaData(alias)!.replacementTargets!
+
+            const sourceRecord = replacementRecord[typeName] || getSharedMetaData(typeName)!.replacementTargets!
+
+            targetRecord.push(...sourceRecord)
+
+            setMetaData(alias, {
+              hasDuplicateImports: true,
             })
           }
 
-          res[name] = name
-
-          return res
-        }, {}))
+          return typeName
+        })
 
         debug('Processed intersection: %O', processedIntersection)
 
@@ -1048,10 +1255,14 @@ export async function extractTypesFromSource(
         // Generate new metadata map from the missing types
         const newMetaDataMap = processedIntersection.reduce<Record<string, TypeMetaData>>((res, typeName) => {
           // Apply new extract alias if exists
-          const metaData = getMetaData(newExtractAliases[typeName] || typeName)
+          const name = newExtractAliases[typeName] || typeName
+          const metaData = getMetaData(name)
 
-          if (metaData)
+          if (metaData) {
+            (metaData as TypeMetaData).replacementTargets ||= replacementRecord[name]
+
             res[typeName] = metaData
+          }
 
           return res
         }, {})
@@ -1064,7 +1275,8 @@ export async function extractTypesFromSource(
   for (const typeName of processedTypes)
     extractTypeByName(typeName)
 
-  debug('MetaData Map After: %O', metaDataMap)
+  debug('Local metadata map (after): %O', localMetaDataMap)
+  debug('Replacement record: %O', replacementRecord)
 
   if (missingTypes.local.length) {
     debug('Find missing types (Local)')
@@ -1075,6 +1287,10 @@ export async function extractTypesFromSource(
   if (missingTypes.requested.length) {
     debug('Find missing types (Requested)')
 
+    /**
+     * NOTE(zorin): For development convenience, we currently convert the export syntaxes to import syntaxes.
+     * This behavior may be changed in the future
+     */
     const groupedExports = groupImports(convertExportsToImports([...namedExports, ...namedFromExports], groupedImports), source, relativePath)
 
     await findMissingTypes(missingTypes.requested, groupedExports)

--- a/src/core/ast.ts
+++ b/src/core/ast.ts
@@ -452,6 +452,8 @@ export async function extractTypesFromSource(
 
       const sourceRecord = getSharedMetaData(maybeAlias)!.replacementTargets!
 
+      emptyMetaData(maybeAlias)
+
       targetRecord.push(...sourceRecord)
     }
     else {
@@ -542,8 +544,8 @@ export async function extractTypesFromSource(
     }
   }
 
-  function deleteMetaData(name: string) {
-    debug('Delete metadata %s', name)
+  function emptyMetaData(name: string) {
+    debug('Empty metadata %s', name)
     localMetaDataMap[name] = undefined
   }
 
@@ -554,7 +556,7 @@ export async function extractTypesFromSource(
 
     const targetRecord = (setMetaData(name, getSharedMetaData(from)!) as TypeMetaData).replacementTargets!
 
-    deleteMetaData(from)
+    emptyMetaData(from)
 
     /**
      * If sourceRecord exists, it means that user also imported the original (local) name of the type

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -7,9 +7,3 @@ export const PLUGIN_NAME = 'vite-plugin-vue-type-imports'
 
 // Typescript types that the plugin allow to extract.
 export const TS_TYPES_KEYS = ['TSTypeAliasDeclaration', 'TSInterfaceDeclaration', 'TSEnumDeclaration']
-
-// Messages that can be reused for logger
-export enum LogMsg {
-  SUGGEST_TYPE_ALIAS = 'If you want to use types with the same definition but different names, use type alias instead!',
-  UNEXPECTED_RESULT = 'The results of the transformation will likely not meet your expectations.',
-}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -75,6 +75,7 @@ export function finalize(types: string[], extractResult: ExtractResult): Finaliz
   })
 
   debug('Result: %O', result)
+  debug('Extra specifiers 3: %O', extraSpecifiers)
 
   // Collect replacements to clean up import specifiers
   importNodes.forEach((i) => {
@@ -143,6 +144,26 @@ export function finalize(types: string[], extractResult: ExtractResult): Finaliz
     }
   })
 
+  /**
+   * NOTE(zorin): Get the order of inlining types
+   * If the order is incorrect, Vue will not get the correct definition of types
+   *
+   * @example
+   * Correct:
+   * ```typescript
+   * type Foo = string
+   * type Bar = Foo
+   *
+   * interface Props {...}
+   * ```
+   * Wrong:
+   * ```typescript
+   * type Bar = Foo
+   * type Foo = string
+   *
+   * interface Props {...}
+   * ```
+   */
   const dependencies = resolveDependencies(result, namesMap, types)
 
   debug('Dependencies: %O', dependencies)

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -41,6 +41,25 @@ export type MaybeNumber = number | null | undefined
 
 export type MaybeNode = Node | null | undefined
 
+/**
+ * References:
+ * https://github.com/tc39/proposal-relative-indexing-method#polyfill
+ * https://github.com/antfu/utils/blob/main/src/array.ts
+ */
+export function at(arr: [], index: number): undefined
+export function at<T>(arr: T[], index: number): T
+export function at<T>(arr: T[] | [], index: number): T | undefined {
+  const length = arr.length
+
+  if (index < 0)
+    index += length
+
+  if (index < 0 || index > length || !length)
+    return undefined
+
+  return arr[index]
+}
+
 export function debuggerFactory(namespace: string) {
   return (name?: string) => {
     const _debugger = _debug(`${PLUGIN_NAME}:${namespace}${name ? `:${name}` : ''}`)
@@ -455,7 +474,7 @@ export function mergeLogMsg(options: LogOptions & { msg: string }) {
   ].filter(notNullish)
 
   // Push newline if the last line is not an empty string
-  if (result.at(-1))
+  if (at(result, -1))
     result.push('')
 
   return result.join('\n')

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -202,7 +202,6 @@ export type LocationMap = Record<string, Pick<IImport, 'start' | 'end'>>
 
 export interface ImportInfo {
   aliases: Record<string, string>
-  locationMap: LocationMap
   localSpecifiers: string[]
 }
 
@@ -238,7 +237,6 @@ export function groupImports(imports: IImport[], source: string, fileName: strin
   return imports.reduce<GroupedImports>((res, rawImport) => {
     res[rawImport.path] ||= {
       aliases: {},
-      locationMap: {},
       localSpecifiers: [],
     }
 
@@ -251,11 +249,6 @@ export function groupImports(imports: IImport[], source: string, fileName: strin
 
     const importInfo = res[rawImport.path]
     importInfo.localSpecifiers.push(rawImport.local)
-    importInfo.locationMap[rawImport.local] = {
-      start: rawImport.start,
-      end: rawImport.end,
-    }
-
     importedSpecifiers.push(rawImport.imported)
 
     if (rawImport.local !== rawImport.imported)

--- a/test/__snapshots__/common.test.ts.snap
+++ b/test/__snapshots__/common.test.ts.snap
@@ -1,5 +1,157 @@
 // Vitest Snapshot v1
 
+exports[`Common > Duplicate imports > Export aliases > 1.ts (default) 1`] = `
+"<script lang=\\"ts\\" setup>
+type _VTI_TYPE_Bar = 'foo'
+interface Props {
+  foo: _VTI_TYPE_Bar
+  bar: _VTI_TYPE_Bar
+}
+defineProps<Props>()
+</script>
+"
+`;
+
+exports[`Common > Duplicate imports > Export aliases > 2.ts (default) 1`] = `
+"<script lang=\\"ts\\" setup>
+type _VTI_TYPE_Bar = 'foo'
+interface Props {
+  foo: _VTI_TYPE_Bar
+  bar: _VTI_TYPE_Bar
+}
+defineProps<Props>()
+</script>
+"
+`;
+
+exports[`Common > Duplicate imports > Export aliases > multi-level.ts (default) 1`] = `
+"<script lang=\\"ts\\" setup>
+type _VTI_TYPE_Foo = 'foo'
+interface Props {
+  foo: _VTI_TYPE_Foo
+  bar: _VTI_TYPE_Foo
+}
+defineProps<Props>()
+</script>
+"
+`;
+
+exports[`Common > Duplicate imports > Import aliases > 1.ts (default) 1`] = `
+"<script lang=\\"ts\\" setup>
+type _VTI_TYPE_Bar = 'foo'
+interface Props {
+  foo: _VTI_TYPE_Bar
+  bar: _VTI_TYPE_Bar
+}
+defineProps<Props>()
+</script>
+"
+`;
+
+exports[`Common > Duplicate imports > Import aliases > 2.ts (default) 1`] = `
+"<script lang=\\"ts\\" setup>
+type _VTI_TYPE_Bar = 'foo'
+interface Props {
+  foo: _VTI_TYPE_Bar
+  bar: _VTI_TYPE_Bar
+}
+defineProps<Props>()
+</script>
+"
+`;
+
+exports[`Common > Duplicate imports > Import aliases > multi-level.ts (default) 1`] = `
+"<script lang=\\"ts\\" setup>
+type _VTI_TYPE_Bar = 'foo'
+interface Props {
+  foo: _VTI_TYPE_Bar
+  bar: _VTI_TYPE_Bar
+}
+defineProps<Props>()
+</script>
+"
+`;
+
+exports[`Common > Duplicate imports > Import export default > 1.ts (default) 1`] = `
+"<script lang=\\"ts\\" setup>
+type _VTI_TYPE_Bar = 'foo'
+interface Props {
+  foo: _VTI_TYPE_Bar
+  bar: _VTI_TYPE_Bar
+}
+defineProps<Props>()
+</script>
+"
+`;
+
+exports[`Common > Duplicate imports > Import export default > 2.ts (default) 1`] = `
+"<script lang=\\"ts\\" setup>
+type _VTI_TYPE_Bar = 'foo'
+interface Props {
+  foo: _VTI_TYPE_Bar
+  bar: _VTI_TYPE_Bar
+}
+defineProps<Props>()
+</script>
+"
+`;
+
+exports[`Common > Duplicate imports > Import export default > multi-level.ts (default) 1`] = `
+"<script lang=\\"ts\\" setup>
+type _VTI_TYPE_Bar = 'foo'
+interface Props {
+  foo: _VTI_TYPE_Bar
+  bar: _VTI_TYPE_Bar
+}
+defineProps<Props>()
+</script>
+"
+`;
+
+exports[`Common > Enum types > Default > empty.ts (default) 1`] = `
+"<script lang=\\"ts\\" setup>
+type _VTI_TYPE_Foo = /* empty-enum */ number | string
+interface Props {
+  foo: _VTI_TYPE_Foo
+}
+defineProps<Props>()
+</script>
+"
+`;
+
+exports[`Common > Enum types > Default > mixed.ts (default) 1`] = `
+"<script lang=\\"ts\\" setup>
+type _VTI_TYPE_Foo = /* enum */ number | string
+interface Props {
+  foo: _VTI_TYPE_Foo
+}
+defineProps<Props>()
+</script>
+"
+`;
+
+exports[`Common > Enum types > Default > number.ts (default) 1`] = `
+"<script lang=\\"ts\\" setup>
+type _VTI_TYPE_Foo = /* enum */ number
+interface Props {
+  foo: _VTI_TYPE_Foo
+}
+defineProps<Props>()
+</script>
+"
+`;
+
+exports[`Common > Enum types > Default > string.ts (default) 1`] = `
+"<script lang=\\"ts\\" setup>
+type _VTI_TYPE_Foo = /* enum */ string
+interface Props {
+  foo: _VTI_TYPE_Foo
+}
+defineProps<Props>()
+</script>
+"
+`;
+
 exports[`Common > Export aliases > Default > index.ts (default) 1`] = `
 "<script lang=\\"ts\\" setup>
 type _VTI_TYPE_Foo = string
@@ -113,6 +265,33 @@ exports[`Common > Import export default > Use aliases > 3.ts (default) 1`] = `
 type _VTI_TYPE_Foo = string
 interface Props {
   foo: _VTI_TYPE_Foo
+}
+defineProps<Props>()
+</script>
+"
+`;
+
+exports[`Common > Import same type implicitly > Default > 1.ts (default) 1`] = `
+"<script lang=\\"ts\\" setup>
+type _VTI_TYPE_Foo = 'foo'
+interface Props {
+  foo: _VTI_TYPE_Foo
+  bar: _VTI_TYPE_Foo
+  baz: _VTI_TYPE_Foo
+}
+defineProps<Props>()
+</script>
+"
+`;
+
+exports[`Common > Import same type implicitly > Default > 2.ts (default) 1`] = `
+"<script lang=\\"ts\\" setup>
+type _VTI_TYPE_Foo = 'foo'
+type _VTI_TYPE_A = _VTI_TYPE_Foo
+interface Props {
+  foo: _VTI_TYPE_Foo
+  bar: _VTI_TYPE_Foo
+  baz: _VTI_TYPE_A
 }
 defineProps<Props>()
 </script>
@@ -256,6 +435,21 @@ exports[`Common > Redeclaration of types > Same name > index.ts (default) 1`] = 
 type _VTI_TYPE_Foo_2 = 'foo_2'
 type _VTI_TYPE_Bar = _VTI_TYPE_Foo_2
 type _VTI_TYPE_Foo = 'foo'
+interface Props {
+  foo: _VTI_TYPE_Foo
+  bar: _VTI_TYPE_Bar
+}
+defineProps<Props>()
+</script>
+"
+`;
+
+exports[`Common > Reference in property > Default > index.ts (default) 1`] = `
+"<script lang=\\"ts\\" setup>
+interface _VTI_TYPE_Foo {
+  foo: 'foo'
+}
+type _VTI_TYPE_Bar = _VTI_TYPE_Foo
 interface Props {
   foo: _VTI_TYPE_Foo
   bar: _VTI_TYPE_Bar

--- a/test/__snapshots__/common.test.ts.snap
+++ b/test/__snapshots__/common.test.ts.snap
@@ -14,10 +14,10 @@ defineProps<Props>()
 
 exports[`Common > Duplicate imports > Export aliases > 2.ts (default) 1`] = `
 "<script lang=\\"ts\\" setup>
-type _VTI_TYPE_Bar = 'foo'
+type _VTI_TYPE_Foo = 'foo'
 interface Props {
-  foo: _VTI_TYPE_Bar
-  bar: _VTI_TYPE_Bar
+  foo: _VTI_TYPE_Foo
+  bar: _VTI_TYPE_Foo
 }
 defineProps<Props>()
 </script>
@@ -74,10 +74,10 @@ defineProps<Props>()
 
 exports[`Common > Duplicate imports > Import export default > 1.ts (default) 1`] = `
 "<script lang=\\"ts\\" setup>
-type _VTI_TYPE_Bar = 'foo'
+type _VTI_TYPE_Foo = 'foo'
 interface Props {
-  foo: _VTI_TYPE_Bar
-  bar: _VTI_TYPE_Bar
+  foo: _VTI_TYPE_Foo
+  bar: _VTI_TYPE_Foo
 }
 defineProps<Props>()
 </script>
@@ -86,10 +86,10 @@ defineProps<Props>()
 
 exports[`Common > Duplicate imports > Import export default > 2.ts (default) 1`] = `
 "<script lang=\\"ts\\" setup>
-type _VTI_TYPE_Bar = 'foo'
+type _VTI_TYPE_Foo = 'foo'
 interface Props {
-  foo: _VTI_TYPE_Bar
-  bar: _VTI_TYPE_Bar
+  foo: _VTI_TYPE_Foo
+  bar: _VTI_TYPE_Foo
 }
 defineProps<Props>()
 </script>
@@ -98,10 +98,10 @@ defineProps<Props>()
 
 exports[`Common > Duplicate imports > Import export default > multi-level.ts (default) 1`] = `
 "<script lang=\\"ts\\" setup>
-type _VTI_TYPE_Bar = 'foo'
+type _VTI_TYPE_Foo = 'foo'
 interface Props {
-  foo: _VTI_TYPE_Bar
-  bar: _VTI_TYPE_Bar
+  foo: _VTI_TYPE_Foo
+  bar: _VTI_TYPE_Foo
 }
 defineProps<Props>()
 </script>

--- a/test/__snapshots__/dynamic.test.ts.snap
+++ b/test/__snapshots__/dynamic.test.ts.snap
@@ -1,5 +1,36 @@
 // Vitest Snapshot v1
 
+exports[`Dynamic > Enum types > Default > index.vue (default) 1`] = `
+"<script lang=\\"ts\\" setup>
+type _VTI_TYPE_Foo = /* enum */ number
+interface Props {
+  foo: _VTI_TYPE_Foo
+}
+import { Foo } from './_types'
+defineProps<Props>()
+</script>
+"
+`;
+
+exports[`Dynamic > Enum types > Default > local.vue (default) 1`] = `
+"<script lang=\\"ts\\" setup>
+type _VTI_TYPE_Foo = /* enum */ number
+interface Props {
+  foo: _VTI_TYPE_Foo
+}
+// Weird output when using eslint, disable it temporarily
+/* eslint-disable eslint-comments/no-unlimited-disable */
+/* eslint-disable */
+enum Foo {
+  Bar,
+  Baz,
+  Qux,
+}
+defineProps<Props>()
+</script>
+"
+`;
+
 exports[`Dynamic > Interface extends interface > Has reference > 1.vue (default) 1`] = `
 "<script lang=\\"ts\\" setup>
 type Baz = boolean
@@ -73,10 +104,14 @@ defineProps<Props>()
 
 exports[`Dynamic > Interface extends interface > Has reference > external_2.vue (default) 1`] = `
 "<script lang=\\"ts\\" setup>
-interface _VTI_TYPE_BaseProps {}
+type _VTI_TYPE_Baz = boolean
+interface _VTI_TYPE_BaseProps {
+  baz: _VTI_TYPE_Baz
+}
 type Bar = number
 type Foo = string
 interface Props {
+  baz: _VTI_TYPE_Baz
   foo: Foo
   bar: Bar
   base: _VTI_TYPE_BaseProps
@@ -88,10 +123,17 @@ defineProps<Props>()
 
 exports[`Dynamic > Interface extends interface > Has reference > external_3.vue (default) 1`] = `
 "<script lang=\\"ts\\" setup>
-interface _VTI_TYPE_BaseProps {}
+type _VTI_TYPE_Qux = 'qux'
+type _VTI_TYPE_Baz = boolean
+interface _VTI_TYPE_BaseProps {
+  qux: _VTI_TYPE_Qux
+  baz: _VTI_TYPE_Baz
+}
 type Bar = number
 type Foo = string
 interface Props {
+  qux: _VTI_TYPE_Qux
+  baz: _VTI_TYPE_Baz
   foo: Foo
   bar: Bar
   base: _VTI_TYPE_BaseProps

--- a/test/fixtures/common/duplicate-imports/export-aliases/1.ts
+++ b/test/fixtures/common/duplicate-imports/export-aliases/1.ts
@@ -1,0 +1,6 @@
+import type { Bar, Foo } from './types/1'
+
+export interface Props {
+  foo: Foo
+  bar: Bar
+}

--- a/test/fixtures/common/duplicate-imports/export-aliases/2.ts
+++ b/test/fixtures/common/duplicate-imports/export-aliases/2.ts
@@ -1,0 +1,6 @@
+import type { Bar, Foo } from './types/2'
+
+export interface Props {
+  foo: Foo
+  bar: Bar
+}

--- a/test/fixtures/common/duplicate-imports/export-aliases/multi-level.ts
+++ b/test/fixtures/common/duplicate-imports/export-aliases/multi-level.ts
@@ -1,0 +1,6 @@
+import type { Bar, Foo } from './types/3'
+
+export interface Props {
+  foo: Foo
+  bar: Bar
+}

--- a/test/fixtures/common/duplicate-imports/export-aliases/types/1.ts
+++ b/test/fixtures/common/duplicate-imports/export-aliases/types/1.ts
@@ -1,0 +1,3 @@
+type Foo = 'foo'
+
+export { Foo, Foo as Bar }

--- a/test/fixtures/common/duplicate-imports/export-aliases/types/2.ts
+++ b/test/fixtures/common/duplicate-imports/export-aliases/types/2.ts
@@ -1,0 +1,3 @@
+type F = 'foo'
+
+export { F as Foo, F as Bar }

--- a/test/fixtures/common/duplicate-imports/export-aliases/types/3.ts
+++ b/test/fixtures/common/duplicate-imports/export-aliases/types/3.ts
@@ -1,0 +1,1 @@
+export { Foo, Bar } from './4'

--- a/test/fixtures/common/duplicate-imports/export-aliases/types/4.ts
+++ b/test/fixtures/common/duplicate-imports/export-aliases/types/4.ts
@@ -1,0 +1,3 @@
+type F = 'foo'
+
+export { F as Foo, F as Bar }

--- a/test/fixtures/common/duplicate-imports/import-aliases/1.ts
+++ b/test/fixtures/common/duplicate-imports/import-aliases/1.ts
@@ -1,0 +1,6 @@
+import type { Foo as Bar, Foo } from './types/1'
+
+export interface Props {
+  foo: Foo
+  bar: Bar
+}

--- a/test/fixtures/common/duplicate-imports/import-aliases/2.ts
+++ b/test/fixtures/common/duplicate-imports/import-aliases/2.ts
@@ -1,0 +1,6 @@
+import type { Foo as Bar, Foo as Baz } from './types/1'
+
+export interface Props {
+  foo: Bar
+  bar: Baz
+}

--- a/test/fixtures/common/duplicate-imports/import-aliases/multi-level.ts
+++ b/test/fixtures/common/duplicate-imports/import-aliases/multi-level.ts
@@ -1,0 +1,6 @@
+import type { Foo as Bar, Foo as Baz } from './types/1'
+
+export interface Props {
+  foo: Bar
+  bar: Baz
+}

--- a/test/fixtures/common/duplicate-imports/import-aliases/types/1.ts
+++ b/test/fixtures/common/duplicate-imports/import-aliases/types/1.ts
@@ -1,0 +1,1 @@
+export type Foo = 'foo'

--- a/test/fixtures/common/duplicate-imports/import-aliases/types/2.ts
+++ b/test/fixtures/common/duplicate-imports/import-aliases/types/2.ts
@@ -1,0 +1,1 @@
+export { Foo } from './3'

--- a/test/fixtures/common/duplicate-imports/import-aliases/types/3.ts
+++ b/test/fixtures/common/duplicate-imports/import-aliases/types/3.ts
@@ -1,0 +1,1 @@
+export type Foo = 'foo'

--- a/test/fixtures/common/duplicate-imports/import-export-default/1.ts
+++ b/test/fixtures/common/duplicate-imports/import-export-default/1.ts
@@ -1,0 +1,7 @@
+/* eslint-disable import/no-named-default */
+import type { default as Bar, default as Foo } from './types/1'
+
+export interface Props {
+  foo: Foo
+  bar: Bar
+}

--- a/test/fixtures/common/duplicate-imports/import-export-default/2.ts
+++ b/test/fixtures/common/duplicate-imports/import-export-default/2.ts
@@ -1,0 +1,7 @@
+/* eslint-disable import/no-named-default */
+import type { Bar, default as Foo } from './types/2'
+
+export interface Props {
+  foo: Foo
+  bar: Bar
+}

--- a/test/fixtures/common/duplicate-imports/import-export-default/multi-level.ts
+++ b/test/fixtures/common/duplicate-imports/import-export-default/multi-level.ts
@@ -1,0 +1,7 @@
+/* eslint-disable import/no-named-default */
+import type { default as Bar, default as Foo } from './types/2'
+
+export interface Props {
+  foo: Foo
+  bar: Bar
+}

--- a/test/fixtures/common/duplicate-imports/import-export-default/types/1.ts
+++ b/test/fixtures/common/duplicate-imports/import-export-default/types/1.ts
@@ -1,0 +1,3 @@
+type Foo = 'foo'
+
+export default Foo

--- a/test/fixtures/common/duplicate-imports/import-export-default/types/2.ts
+++ b/test/fixtures/common/duplicate-imports/import-export-default/types/2.ts
@@ -1,0 +1,3 @@
+type Foo = 'foo'
+
+export { Foo as default, Foo as Bar }

--- a/test/fixtures/common/duplicate-imports/import-export-default/types/3.ts
+++ b/test/fixtures/common/duplicate-imports/import-export-default/types/3.ts
@@ -1,0 +1,1 @@
+export { default } from './4'

--- a/test/fixtures/common/duplicate-imports/import-export-default/types/4.ts
+++ b/test/fixtures/common/duplicate-imports/import-export-default/types/4.ts
@@ -1,0 +1,3 @@
+type Foo = 'foo'
+
+export { Foo as default, Foo as Bar }

--- a/test/fixtures/common/enum-types/default/empty.ts
+++ b/test/fixtures/common/enum-types/default/empty.ts
@@ -1,0 +1,5 @@
+export enum Foo {}
+
+export interface Props {
+  foo: Foo
+}

--- a/test/fixtures/common/enum-types/default/mixed.ts
+++ b/test/fixtures/common/enum-types/default/mixed.ts
@@ -1,0 +1,9 @@
+export enum Foo {
+  Bar,
+  Baz = 'baz',
+  Qux = 'qux',
+}
+
+export interface Props {
+  foo: Foo
+}

--- a/test/fixtures/common/enum-types/default/number.ts
+++ b/test/fixtures/common/enum-types/default/number.ts
@@ -1,0 +1,9 @@
+export enum Foo {
+  Bar,
+  Baz,
+  Qux,
+}
+
+export interface Props {
+  foo: Foo
+}

--- a/test/fixtures/common/enum-types/default/string.ts
+++ b/test/fixtures/common/enum-types/default/string.ts
@@ -1,0 +1,9 @@
+export enum Foo {
+  Bar = 'bar',
+  Baz = 'baz',
+  Qux = 'qux',
+}
+
+export interface Props {
+  foo: Foo
+}

--- a/test/fixtures/common/import-same-type-implicitly/default/1.ts
+++ b/test/fixtures/common/import-same-type-implicitly/default/1.ts
@@ -1,0 +1,8 @@
+import type { Foo } from './types/1'
+import type { Bar } from './types/2'
+
+export interface Props {
+  foo: Foo
+  bar: Bar
+  baz: Bar
+}

--- a/test/fixtures/common/import-same-type-implicitly/default/2.ts
+++ b/test/fixtures/common/import-same-type-implicitly/default/2.ts
@@ -1,0 +1,10 @@
+import type { Foo } from './types/1'
+import type { Bar } from './types/2'
+
+type A = Bar
+
+export interface Props {
+  foo: Foo
+  bar: Bar
+  baz: A
+}

--- a/test/fixtures/common/import-same-type-implicitly/default/types/1.ts
+++ b/test/fixtures/common/import-same-type-implicitly/default/types/1.ts
@@ -1,0 +1,1 @@
+export type Foo = 'foo'

--- a/test/fixtures/common/import-same-type-implicitly/default/types/2.ts
+++ b/test/fixtures/common/import-same-type-implicitly/default/types/2.ts
@@ -1,0 +1,1 @@
+export { Foo as Bar } from './1'

--- a/test/fixtures/common/reference-in-property/default/index.ts
+++ b/test/fixtures/common/reference-in-property/default/index.ts
@@ -1,0 +1,10 @@
+interface Foo {
+  foo: 'foo'
+}
+
+type Bar = Foo
+
+export interface Props {
+  foo: Foo
+  bar: Bar
+}

--- a/test/fixtures/dynamic/enum-types/default/_types.ts
+++ b/test/fixtures/dynamic/enum-types/default/_types.ts
@@ -1,0 +1,5 @@
+export enum Foo {
+  Bar,
+  Baz,
+  Qux,
+}

--- a/test/fixtures/dynamic/enum-types/default/index.vue
+++ b/test/fixtures/dynamic/enum-types/default/index.vue
@@ -1,0 +1,9 @@
+<script lang="ts" setup>
+import type { Foo } from './_types'
+
+interface Props {
+  foo: Foo
+}
+
+defineProps<Props>()
+</script>

--- a/test/fixtures/dynamic/enum-types/default/local.vue
+++ b/test/fixtures/dynamic/enum-types/default/local.vue
@@ -1,0 +1,16 @@
+<script lang="ts" setup>
+// Weird output when using eslint, disable it temporarily
+/* eslint-disable eslint-comments/no-unlimited-disable */
+/* eslint-disable */
+enum Foo {
+  Bar,
+  Baz,
+  Qux,
+}
+
+interface Props {
+  foo: Foo
+}
+
+defineProps<Props>()
+</script>

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -4,7 +4,7 @@ const isProduction = process.env.NODE_ENV === 'production'
 
 export default defineConfig({
   define: {
-    'import.meta.vitest': 'undefined',
+    'process.env.VITEST': 'undefined',
   },
   minify: true,
   format: ['esm', 'cjs'],


### PR DESCRIPTION
## Description
### Bug fixes
- Extract the interface itself even it is referenced in a property.
Reason: We just extract an empty interface when it is referenced in a property at the moment. This may lead to wrong result because we cannot determine which types this type is referenced by.
- Improve the way of changing name to the already extracted's when types imported implicitly depends on same types
- Improve the way of handling duplicate imports/exports
- Improve the way of finding types
- Fix infinite loop when the type references itself (see caveats in `README.md`)
- Do not remove import when extracting enum types referenced from SFC, closes #20 
- Fix noisy warnings

### Other changes
- Add comment `/* enum */` and `/* empty-enum */` when extracting enum types
- Use `process.env.VITEST` instead of `import.meta.vitest`
- Update deps
- Update docs