### PR TITLE
fix: move type not found warning to debug level, closes #34

### DIFF
--- a/src/core/ast.ts
+++ b/src/core/ast.ts
@@ -38,7 +38,6 @@ import {
   isTSTypes,
   isWithDefaults,
   resolveModulePath,
-  warn,
 } from './utils'
 
 const enum Prefixes {
@@ -1279,7 +1278,7 @@ export async function extractTypesFromSource(
       }
       else {
         if (!hasExportAllDecl)
-          warn(`Cannot find type: ${typeName}`)
+          debug('Cannot find type: %s', typeName)
 
         unresolved.push(typeName)
       }


### PR DESCRIPTION
The warnings may be annoying when using TS's builtin types.

We temporarily move it to debug level until #28 is resolved.